### PR TITLE
Fix segfault when running xcb_get_image_reply on QHD desktop

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,15 @@
 ---
-Checks: 'bugprone-*,clang-analyzer-cplusplus.InnerPointer,cppcoreguidelines-*
-    ,readability-*,clang-analyzer-core-*,clang-analyzer-cplusplus-*
-    ,clang-analyzer-deadcode-*,clang-analyzer-nullability-*'
+Checks: 'bugprone-*,
+        clang-analyzer-cplusplus.InnerPointer,
+        cppcoreguidelines-*,
+        readability-*,
+        clang-analyzer-core-*,
+        clang-analyzer-cplusplus-*,
+        clang-analyzer-deadcode-*,
+        clang-analyzer-nullability-*,
+        -implicit-int-float-conversion,
+        -float-conversion,
+        -cppcoreguidelines-avoid-c-arrays'
 HeaderFilterRegex: ''
 FormatStyle:     file
 

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -41,7 +41,6 @@ function(set_project_warnings project_name)
       -Wunused # warn on anything being unused
       -Woverloaded-virtual # warn if you overload (not override) a virtual function
       -Wpedantic # warn if non-standard C++ is used
-      -Wconversion # warn on type conversions that may lose data
       -Wsign-conversion # warn on sign conversions
       -Wnull-dereference # warn if a null dereference is detected
       -Wdouble-promotion # warn if float is implicit promoted to double

--- a/config.hpp
+++ b/config.hpp
@@ -1,0 +1,1 @@
+./src/config.hpp

--- a/config.hpp
+++ b/config.hpp
@@ -1,1 +1,0 @@
-./src/config.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Define name of the binary
-add_executable(dexpo dexpo.cpp desktop_pixmap.cpp drawable.cpp)
+# add_executable(dexpo dexpo.cpp desktop_pixmap.cpp drawable.cpp)
 add_executable(example example_desktop_pixmap_usage.cpp desktop_pixmap.cpp
                        drawable.cpp)
 
 # Tells compiler to link xcb to our build
-target_link_libraries(
-  dexpo
-  PRIVATE project_options project_warnings
-  PUBLIC xcb)
+# target_link_libraries(
+#   dexpo
+#   PRIVATE project_options project_warnings
+#   PUBLIC xcb)
 
 # Tells compiler to link xcb to our build
 target_link_libraries(

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,6 +1,6 @@
-// Displayed Screenshot width
+// Displayed Screenshot width.
 // Will be calculated based on height and screen ratio if set to zero
-const int k_dexpo_width = 1500;
-// Displayed screenshot heigth
+const int k_dexpo_width = 500;
+// Displayed screenshot height.
 // Will be calculated based on width and screen ratio if set to zero
 const int k_dexpo_height = 0;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,6 +1,6 @@
 // Displayed Screenshot width
 // Will be calculated based on height and screen ratio if set to zero
-const int k_dexpo_width = 1000;
+const int k_dexpo_width = 1500;
 // Displayed screenshot heigth
 // Will be calculated based on width and screen ratio if set to zero
 const int k_dexpo_height = 0;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,0 +1,6 @@
+// Displayed Screenshot width
+// Will be calculated based on height and screen ratio if set to zero
+const int k_dexpo_width = 0;
+// Displayed screenshot heigth
+// Will be calculated based on width and screen ratio if set to zero
+const int k_dexpo_height = 500;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,6 +1,6 @@
 // Displayed Screenshot width
 // Will be calculated based on height and screen ratio if set to zero
-const int k_dexpo_width = 1300;
+const int k_dexpo_width = 1000;
 // Displayed screenshot heigth
 // Will be calculated based on width and screen ratio if set to zero
 const int k_dexpo_height = 0;

--- a/src/desktop_pixmap.cpp
+++ b/src/desktop_pixmap.cpp
@@ -136,7 +136,11 @@ desktop_pixmap::save_screen (pixmap_format pixmap_format)
     }
   this->width = resized_width;
   this->height = resized_height;
-            
+}
+
+void 
+desktop_pixmap::render_geometries ()
+{
 
 }
 
@@ -182,12 +186,12 @@ desktop_pixmap::resize (int old_width, int old_height, int new_dimension,
     case 'h':
       new_height = new_dimension;
       det = float (old_height) / float (new_height);
-      new_width = round (float (old_width) / det);
+      new_width = std::lround (float (old_width) / det);
       break;
     case 'w':
       new_width = new_dimension;
       det = float (old_width) / float (new_width);
-      new_height = round (float (old_height) / det);
+      new_height = std::lround (float (old_height) / det);
       break;
     };
 
@@ -208,9 +212,9 @@ desktop_pixmap::resize (int old_width, int old_height, int new_dimension,
                             // ceil(det)! doesn't switch pixels!
                     {
                       sum = sum
-                            + this->image_ptr[int ((i * det)) * 4 + xi
+                            + this->image_ptr[std::lround ((i * det)) * 4 + xi
                                               + old_width * 4
-                                                    * (int ((j * det)) + k)
+                                                    * (std::lround ((j * det)) + k)
                                               + z * 4];
                       // aprox. column bite + color chanell + aprox. row * (cur
                       // row counter + count of bites needed by y) + count of

--- a/src/desktop_pixmap.cpp
+++ b/src/desktop_pixmap.cpp
@@ -131,7 +131,7 @@ desktop_pixmap::save_screen (pixmap_format pixmap_format)
       // Not freeing gi_reply causes memory leak,
       // as xcb_get_image always allocates new space
       // This deallocates saved image on x server
-      delete[] this->gi_reply;
+      free(this->gi_reply);
     }
   this->width = resized_width;
   this->height = resized_height;

--- a/src/desktop_pixmap.cpp
+++ b/src/desktop_pixmap.cpp
@@ -5,7 +5,7 @@
 #include <ostream>
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
-#define MAX_MALLOC 1920 * 1080 / 2
+#define MAX_MALLOC 16711568
 
 desktop_pixmap::desktop_pixmap (
     const short x,          ///< x coordinate of the top left corner
@@ -128,7 +128,6 @@ desktop_pixmap::save_screen (pixmap_format pixmap_format)
                      this->length, this->image_ptr);
 
       i++;
-
       // Not freeing gi_reply causes memory leak,
       // as xcb_get_image always allocates new space
       // This deallocates saved image on x server
@@ -141,7 +140,7 @@ desktop_pixmap::save_screen (pixmap_format pixmap_format)
 void 
 desktop_pixmap::render_geometries ()
 {
-
+  
 }
 
 void
@@ -161,12 +160,12 @@ desktop_pixmap::create_gc ()
 }
 
 void
-desktop_pixmap::create_pixmap (int resized_width, int resized_height)
+desktop_pixmap::create_pixmap (int pix_width, int pix_height)
 {
   this->pixmap_id = xcb_generate_id (drawable::c_);
   xcb_create_pixmap (drawable::c_, drawable::screen_->root_depth,
-                     this->pixmap_id, drawable::screen_->root, resized_width,
-                     resized_height);
+                     this->pixmap_id, drawable::screen_->root, pix_width,
+                     pix_height);
 }
 
 void
@@ -212,9 +211,9 @@ desktop_pixmap::resize (int old_width, int old_height, int new_dimension,
                             // ceil(det)! doesn't switch pixels!
                     {
                       sum = sum
-                            + this->image_ptr[std::lround ((i * det)) * 4 + xi
+                            + this->image_ptr[std::lround (i * det) * 4 + xi
                                               + old_width * 4
-                                                    * (std::lround ((j * det)) + k)
+                                                    * (std::lround (j * det) + k)
                                               + z * 4];
                       // aprox. column bite + color chanell + aprox. row * (cur
                       // row counter + count of bites needed by y) + count of

--- a/src/desktop_pixmap.cpp
+++ b/src/desktop_pixmap.cpp
@@ -1,15 +1,14 @@
 #include "desktop_pixmap.hpp"
 #include "config.hpp"
-#include <iostream>
-#include <math.h>
-#include <ostream>
+#include <memory>
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
-#define MAX_MALLOC 16711568
+
+#define MAX_MALLOC 16711568 // Workaround for xcb_get_image_reply allocation
 
 desktop_pixmap::desktop_pixmap (
-    const short x,          ///< x coordinate of the top left corner
-    const short y,          ///< y coordinate of the top left corner
+    const int16_t x,        ///< x coordinate of the top left corner
+    const int16_t y,        ///< y coordinate of the top left corner
     const uint16_t width,   ///< width of display
     const uint16_t height,  ///< height of display
     const std::string &name ///< _NET_WM_NAME of display
@@ -17,43 +16,44 @@ desktop_pixmap::desktop_pixmap (
     : drawable (x, y, width, height)
 {
   this->name = name;
-  this->format = kZPixmap; // Default to the fastest pixmap
 
   // Initializing non built-in types to zeros
   this->image_ptr = nullptr;
   this->pixmap_id = 0;
   this->length = 0;
-  this->gi_reply = nullptr;
 
-  // Initialize grahic context if it doesn't exist
+  // Initialize graphic context if it doesn't exist
   if (!desktop_pixmap::gc_)
     {
       create_gc ();
     }
 
-  // Calculate pixmap width and height based on config values
+  // Check if both are set or unset simultaneously
+  static_assert ((k_dexpo_height == 0) != (k_dexpo_width == 0),
+                 "Height and width can't be set or unset simultaneously");
+
   this->pixmap_width = k_dexpo_width;
   this->pixmap_height = k_dexpo_height;
-  if (this->pixmap_width==0)
-  {
-    this->pixmap_width=(float(this->width)/float(this->height))*k_dexpo_height;
-  }
 
-  if (this->pixmap_height==0)
-  {
-    this->pixmap_height=(float(this->height)/float(this->width))*k_dexpo_width;
-  }
+  if (this->pixmap_width == 0)
+    {
+      this->pixmap_width = (this->width / this->height) * this->pixmap_height;
+    }
+  else if (this->pixmap_height == 0)
+    {
+      this->pixmap_height
+          = uint16_t (double (this->height) / double (this->width)
+                      * double (this->pixmap_width));
+    }
 
-  // Create a pixmap
-  // TODO This is suboptimal for compressed screenshots
-  create_pixmap (this->pixmap_width, this->pixmap_height);
+  // Create a small pixmap
+  create_pixmap ();
 }
 
 desktop_pixmap::~desktop_pixmap ()
 {
-  delete[] this->gi_reply;
   xcb_free_pixmap (drawable::c_, this->pixmap_id);
-  // TODO Should you destroy grahic context?
+  // TODO Add separate class to manage graphic context's destructor
 }
 
 /**
@@ -62,91 +62,116 @@ desktop_pixmap::~desktop_pixmap ()
  * @param pixmap_format Bit format for the saved image. Defaults to the faster
  * Z_Pixmap.
  *
- *
  * malloc() can reserve only 16711568 bytes for a pixmap.
  * But ZPixmap of QHD Ultrawide is 3440 * 1440 * 4 = 19814400 bytes long.
- * The while() loop in save_screen fixes this.
+ *
+ * The while() loop in save_screen fixes this. It takes multiple screenshots of
+ * the screen (top to bottom), each taking up less than MAX_MALLOC. It downsizes
+ * each screenshot and puts it on the pixmap.
  */
 void
-desktop_pixmap::save_screen (pixmap_format pixmap_format)
+desktop_pixmap::save_screen ()
 {
-  this->format = pixmap_format;
+  // Set height so that screenshots won't exceed MAX_MALLOC size
+  uint16_t image_height = uint16_t (MAX_MALLOC / this->width / 4);
+  uint16_t image_width = this->width;
 
-  uint16_t screen_width = this->width;
-  uint16_t screen_height = this->height;
+  const uint screen_size = (this->width * this->height * 4);
 
-  uint16_t resized_width = pixmap_width;
-  uint16_t resized_height = pixmap_height;
-
-  uint16_t max_height = MAX_MALLOC / screen_width / 4;
-
-  int16_t y_exception; // max_height might be changed in last iteration,
-  // y must stay i*previous max_height
-
-  int i = 0;
-  while (i * MAX_MALLOC < screen_width * screen_height * 4)
+  uint16_t i = 0;
+  while (i * MAX_MALLOC < screen_size)
     {
+      // Set screen height that we have already captured
+      // New screenshots will be captured with Y offset = image_height_offset
+      int16_t image_height_offset = int16_t (i * image_height);
 
-      y_exception = i * max_height; //sets y point to copy from
+      // Last screenshot will be smaller, so we set its height to what's left
+      image_height = std::min (image_height,
+                               uint16_t (this->height - image_height_offset));
 
-      if (max_height > screen_height - max_height * i)//last iteration may receive a smaller than MAX_MALLOC image
-        {
-          max_height = screen_height - max_height * i;
-        }; 
-
-      //gets image or image part
+      // Request the screenshot of the virtual desktop
       auto gi_cookie = xcb_get_image (
-          drawable::c_,            /* Connection */
-          this->format,            /* Image format */
-          drawable::screen_->root, /* Screenshot relative to root */
-          0, y_exception, screen_width, max_height, /* Dimensions */
+          drawable::c_,              /* Connection */
+          XCB_IMAGE_FORMAT_Z_PIXMAP, /* Z_Pixmap is 100 faster than XY_PIXMAP */
+          drawable::screen_->root,   /* Screenshot relative to root */
+          this->x,                   /* X offset */
+          int16_t (this->y + image_height_offset), /* Y offset */
+          image_width, image_height,               /* Dimensions */
           uint32_t (~0) /* Plane mask (all bits to get all planes) */
       );
 
       // TODO Handle errors
-      // Saving reply to free it later. Fixes memory leak
-      this->gi_reply = xcb_get_image_reply (drawable::c_, gi_cookie, nullptr);
+      // Not freeing gi_reply causes memory leak, as xcb_get_image always
+      // allocates new space for the image
+      auto gi_reply = std::unique_ptr<xcb_get_image_reply_t> (
+          xcb_get_image_reply (drawable::c_, gi_cookie, nullptr));
 
       // Casting for later use
-      this->length
-          = uint32_t (xcb_get_image_data_length (gi_reply));
-      this->image_ptr = xcb_get_image_data (gi_reply);
+      this->length = uint32_t (xcb_get_image_data_length (gi_reply.get ()));
+      this->image_ptr = xcb_get_image_data (gi_reply.get ());
 
-      y_exception = this->height * i;//sets y point to copy to
+      int target_width = this->pixmap_width;
+      int target_height = int (float (image_height) / float (image_width)
+                               * float (this->pixmap_width));
 
-      // TODO: add case if resized height is defined instead of width.
-      resize (
-          screen_width, max_height, resized_width,
-          'w'); 
+      auto pixmap = std::make_unique<uint8_t[]> (this->length + 1);
 
-      // we use this->height and this-> width because this params change in
-      // resize
-      xcb_put_image (drawable::c_, this->format,
-                     this->pixmap_id, /* Pixmap to put image on */
-                     desktop_pixmap::gc_, this->width, this->height, 0,
-                     y_exception, 0, drawable::screen_->root_depth,
-                     this->length, this->image_ptr);
+      resize (this->image_ptr, pixmap.get (), image_width, image_height,
+              target_width, target_height);
+      this->length = uint (target_width * target_height * 4);
+
+      xcb_put_image (drawable::c_, XCB_IMAGE_FORMAT_Z_PIXMAP,
+                     this->pixmap_id,             /* Pixmap to put image on */
+                     desktop_pixmap::gc_,         /* Graphic context */
+                     target_width, target_height, /* Dimensions */
+                     0,                           /* Destination X coordinate */
+                     image_height_offset,         /* Destination Y coordinate */
+                     0, drawable::screen_->root_depth,
+                     this->length, /* Image size in bytes */
+                     pixmap.get ());
 
       i++;
-      // Not freeing gi_reply causes memory leak,
-      // as xcb_get_image always allocates new space
-      // This deallocates saved image on x server
-      free(this->gi_reply);
     }
-  this->width = resized_width;
-  this->height = resized_height;
 }
 
-void 
-desktop_pixmap::render_geometries ()
+/**
+ * Definetely copied. Looks like I'm too retarded to code this myself.
+ * https://stackoverflow.com/questions/28566290
+ *
+ * TODO Optimize and fix warnings
+ */
+void
+desktop_pixmap::resize (const uint8_t *input, uint8_t *output,
+                        int source_width, /* Source dimensions */
+                        int source_height, int target_width, int target_height)
 {
-  
+  const int x_ratio = (int)((source_width << 16) / target_width);
+  const int y_ratio = (int)((source_height << 16) / target_height);
+  const int colors = 4;
+
+  for (int y = 0; y < target_height; y++)
+    {
+      int y2_xsource = ((y * y_ratio) >> 16) * source_width;
+      int i_xdest = y * target_width;
+
+      for (int x = 0; x < target_width; x++)
+        {
+          int x2 = ((x * x_ratio) >> 16);
+          int y2_x2_colors = (y2_xsource + x2) * colors;
+          int i_x_colors = (i_xdest + x) * colors;
+
+          output[i_x_colors] = input[y2_x2_colors];
+          output[i_x_colors + 1] = input[y2_x2_colors + 1];
+          output[i_x_colors + 2] = input[y2_x2_colors + 2];
+          output[i_x_colors + 3] = input[y2_x2_colors + 3];
+        }
+    }
 }
 
 void
 desktop_pixmap::create_gc ()
 {
-  uint32_t mask;
+  uint32_t mask = 0;
   uint32_t values[2];
 
   // TODO Figure out correct mask and values
@@ -156,78 +181,14 @@ desktop_pixmap::create_gc ()
 
   desktop_pixmap::gc_ = xcb_generate_id (c_);
   xcb_create_gc (drawable::c_, desktop_pixmap::gc_, drawable::screen_->root,
-                 mask, values);
+                 mask, &values);
 }
 
 void
-desktop_pixmap::create_pixmap (int pix_width, int pix_height)
+desktop_pixmap::create_pixmap ()
 {
   this->pixmap_id = xcb_generate_id (drawable::c_);
   xcb_create_pixmap (drawable::c_, drawable::screen_->root_depth,
-                     this->pixmap_id, drawable::screen_->root, pix_width,
-                     pix_height);
-}
-
-void
-desktop_pixmap::resize (int old_width, int old_height, int new_dimension,
-                        char flag)
-{
-  // Optional: add bilinear. See belinear_attempts.cpp. This one is ok,
-  // Under condition old dimension/new dimension>20/13.
-  // Some artifacts can appear however.
-  // O(length)
-  int new_width;
-  int new_height;
-  float det;
-  float sum = 0;
-  switch (flag)
-    {
-    case 'h':
-      new_height = new_dimension;
-      det = float (old_height) / float (new_height);
-      new_width = std::lround (float (old_width) / det);
-      break;
-    case 'w':
-      new_width = new_dimension;
-      det = float (old_width) / float (new_width);
-      new_height = std::lround (float (old_height) / det);
-      break;
-    };
-
-  int upper = int (ceil (det));
-  for (int j = 0; j < new_height; j++) // height, rows traversal, pixels!
-    {
-
-      for (int i = 0; i < new_width; i++) // width, bite in row traversal
-        {
-          for (int xi = 0; xi < 3; xi++) // color channel, r g b 0, r g b 0
-            {
-              for (int k = 0; k < upper;
-                   k++) // the number of arguments in sum depends on ceil(det)!
-                        // doesn't switch pixels!
-                {
-                  for (int z = 0; z < upper;
-                       z++) // the number of arguments in sum depends on
-                            // ceil(det)! doesn't switch pixels!
-                    {
-                      sum = sum
-                            + this->image_ptr[std::lround (i * det) * 4 + xi
-                                              + old_width * 4
-                                                    * (std::lround (j * det) + k)
-                                              + z * 4];
-                      // aprox. column bite + color chanell + aprox. row * (cur
-                      // row counter + count of bites needed by y) + count of
-                      // bites needed by x * color chanell multiplier
-                    };
-                };
-              this->image_ptr[i * 4 + xi + j * new_width * 4]
-                  = sum / upper / upper;
-              sum = 0;
-            };
-        };
-    };
-
-  this->length = new_height * new_width * 4;
-  this->width = new_width;
-  this->height = new_height;
+                     this->pixmap_id, drawable::screen_->root,
+                     this->pixmap_width, this->pixmap_height);
 }

--- a/src/desktop_pixmap.hpp
+++ b/src/desktop_pixmap.hpp
@@ -22,40 +22,38 @@ public:
   uint8_t *image_ptr;     ///< Pointer to the image structure. TODO Make smart?
   uint32_t length;        ///< Length of the XImage data structure
   std::string name;       ///< _NET_WM_NAME of display
-  pixmap_format format;   /* XY_PIXMAP = 1, Z_PIXMAP = 2 */
   xcb_pixmap_t pixmap_id; ///< Constant id for the screenshot's pixmap
-  xcb_get_image_reply_t *gi_reply; ///< get_image reply. Saving to free it later
-  uint16_t pixmap_width; //<future screenshot pixmap dimension
-  uint16_t pixmap_height;//<future screenshot pixmap dimension
+  uint16_t pixmap_width;  ///< dimensions of pixmap that stores screenshot
+  uint16_t pixmap_height;
 
   desktop_pixmap (
-      short x,                ///< x coordinate of the top left corner
-      short y,                ///< y coordinate of the top left corner
+      int16_t x,              ///< x coordinate of the top left corner
+      int16_t y,              ///< y coordinate of the top left corner
       uint16_t width,         ///< Width of the display
       uint16_t height,        ///< Height of the display
       const std::string &name ///< Name of the display (_NET_WM_NAME)
   );
-  //rule of five
-  ~desktop_pixmap (); //deleter
+  ~desktop_pixmap (); // deleter
 
-  desktop_pixmap(const desktop_pixmap& other) = delete; // copy constructor
- 
-  desktop_pixmap(desktop_pixmap&& other) noexcept = delete; // move constructor
- 
-  desktop_pixmap& operator=(const desktop_pixmap& other) = delete; // copy assignment
-   
-  desktop_pixmap& operator=(desktop_pixmap&& other) = delete; // move assignment
+  // Explicitly deleting unused constructors to comply with rule of five
+  desktop_pixmap (const desktop_pixmap &other) = delete;
+  desktop_pixmap (desktop_pixmap &&other) noexcept = delete;
+  desktop_pixmap &operator= (const desktop_pixmap &other) = delete;
+  desktop_pixmap &operator= (desktop_pixmap &&other) = delete;
 
   /**
    * Screenshots current desktop and saves it inside instance
    */
-  void save_screen (pixmap_format format = kZPixmap); // Default to fastest
+  void save_screen ();
   /**
    * TODO Resizes screenshot to specified dimensions
    */
-  void resize (int old_width,  int old_height, int new_dim, char flag);
+  void resize (const uint8_t *input, uint8_t *output,
+               int image_width, ///< Width of source image
+               int image_height, int target_width,
+               int target_height); ///< Height of source image
 
-  void render_geometries();
+  void render_geometries ();
 
 private:
   /**
@@ -65,7 +63,7 @@ private:
   /**
    * Initializes instance-level pixmap
    */
-  void create_pixmap (int pix_width, int pix_height);
+  void create_pixmap ();
 };
 
 #endif /* ifndef DESKTOP_PIXMAP_HPP */

--- a/src/desktop_pixmap.hpp
+++ b/src/desktop_pixmap.hpp
@@ -35,7 +35,16 @@ public:
       uint16_t height,        ///< Height of the display
       const std::string &name ///< Name of the display (_NET_WM_NAME)
   );
-  ~desktop_pixmap ();
+  //rule of five
+  ~desktop_pixmap (); //deleter
+
+  desktop_pixmap(const desktop_pixmap& other) = delete; // copy constructor
+ 
+  desktop_pixmap(desktop_pixmap&& other) noexcept = delete; // move constructor
+ 
+  desktop_pixmap& operator=(const desktop_pixmap& other) = delete; // copy assignment
+   
+  desktop_pixmap& operator=(desktop_pixmap&& other) = delete; // move assignment
 
   /**
    * Screenshots current desktop and saves it inside instance
@@ -56,7 +65,7 @@ private:
   /**
    * Initializes instance-level pixmap
    */
-  void create_pixmap (int res_wid, int res_height);
+  void create_pixmap (int pix_width, int pix_height);
 };
 
 #endif /* ifndef DESKTOP_PIXMAP_HPP */

--- a/src/desktop_pixmap.hpp
+++ b/src/desktop_pixmap.hpp
@@ -46,6 +46,8 @@ public:
    */
   void resize (int old_width,  int old_height, int new_dim, char flag);
 
+  void render_geometries();
+
 private:
   /**
    * Initializes class-level graphic context

--- a/src/desktop_pixmap.hpp
+++ b/src/desktop_pixmap.hpp
@@ -40,13 +40,9 @@ public:
    */
   void save_screen (pixmap_format format = kZPixmap); // Default to fastest
   /**
-   * Saves screenshot to the instance's pixmap
-   */
-  void put_screen () const;
-  /**
    * TODO Resizes screenshot to specified dimensions
    */
-  void resize (int new_dim, char flag);
+  void resize (int old_width,  int old_height, int new_dim, char flag);
 
 private:
   /**
@@ -56,7 +52,7 @@ private:
   /**
    * Initializes instance-level pixmap
    */
-  void create_pixmap ();
+  void create_pixmap (int res_wid, int res_height);
 };
 
 #endif /* ifndef DESKTOP_PIXMAP_HPP */

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -1,7 +1,7 @@
 #include "drawable.hpp"
 
-drawable::drawable (const short x, ///< x coordinate of the top left corner
-                    const short y, ///< y coordinate of the top left corner
+drawable::drawable (const int16_t x, ///< x coordinate of the top left corner
+                    const int16_t y, ///< y coordinate of the top left corner
                     const uint16_t width, ///< width of display
                     const uint16_t height ///< height of display
 )

--- a/src/drawable.hpp
+++ b/src/drawable.hpp
@@ -11,27 +11,23 @@ class drawable
 public:
   inline static xcb_connection_t *c_;  ///< Xserver connection
   inline static xcb_screen_t *screen_; ///< X screen
-  short x;                             ///< x coordinate of the top left corner
-  short y;                             ///< y coordinate of the top left corner
+  int16_t x;                           ///< x coordinate of the top left corner
+  int16_t y;                           ///< y coordinate of the top left corner
   uint16_t width;
   uint16_t height;
 
-  drawable (short x,        ///< x coordinate of the top left corner
-            short y,        ///< y coordinate of the top left corner
+  drawable (int16_t x,      ///< x coordinate of the top left corner
+            int16_t y,      ///< y coordinate of the top left corner
             uint16_t width, ///< Width of the display
             uint16_t height ///< Height of the display
   );
-  //rule of five
-  ~drawable  (); //deleter
+  ~drawable ();
 
-  drawable(const drawable& other) = delete; // copy constructor
- 
-  drawable(drawable&& other) noexcept = delete; // move constructor
- 
-  drawable& operator=(const drawable& other) = delete; // copy assignment
-   
-  drawable& operator=(drawable&& other) = delete; // move assignment
-
+  // Explicitly delete unused constructors to comply with rule of five
+  drawable (const drawable &other) = delete;
+  drawable (drawable &&other) noexcept = delete;
+  drawable &operator= (const drawable &other) = delete;
+  drawable &operator= (drawable &&other) = delete;
 };
 
 #endif /* ifndef DRAWABLE_HPP */

--- a/src/drawable.hpp
+++ b/src/drawable.hpp
@@ -21,7 +21,17 @@ public:
             uint16_t width, ///< Width of the display
             uint16_t height ///< Height of the display
   );
-  ~drawable (); // TODO Should you disconnect from Xserver?
+  //rule of five
+  ~drawable  (); //deleter
+
+  drawable(const drawable& other) = delete; // copy constructor
+ 
+  drawable(drawable&& other) noexcept = delete; // move constructor
+ 
+  drawable& operator=(const drawable& other) = delete; // copy assignment
+   
+  drawable& operator=(drawable&& other) = delete; // move assignment
+
 };
 
 #endif /* ifndef DRAWABLE_HPP */

--- a/src/example_desktop_pixmap_usage.cpp
+++ b/src/example_desktop_pixmap_usage.cpp
@@ -16,7 +16,7 @@ main ()
   // FIXME Implement screenshotter that will not capture entire screen at once
   // malloc() can reserve only 16711568 bytes for a pixmap
   // But ZPixmap of QHD Ultrawide is 3440 * 1440 * 4 = 19814400 bytes long
-  desktop_pixmap d (0, 0, 1000, 1000, "DP-1");
+  desktop_pixmap d (0, 0, 1920, 1080, "DP-1");//magic numbers!!!
 
   // connect to the X server and get screen
   c = xcb_connect (NULL, NULL);
@@ -44,12 +44,10 @@ main ()
   xcb_map_window (c, window_id);
 
   d.save_screen ();
-  d.put_screen ();
-
   // Mapping pixmap onto window
   while (1)
     {
-      usleep (100000);
+      usleep (10);
 
       xcb_copy_area (c, d.pixmap_id, window_id, desktop_pixmap::gc_, 0, 0, 0, 0,
                      d.width, d.height);

--- a/src/example_desktop_pixmap_usage.cpp
+++ b/src/example_desktop_pixmap_usage.cpp
@@ -47,7 +47,7 @@ main ()
   // Mapping pixmap onto window
   while (1)
     {
-      usleep (10);
+      usleep (10000);
 
       xcb_copy_area (c, d.pixmap_id, window_id, desktop_pixmap::gc_, 0, 0, 0, 0,
                      d.width, d.height);


### PR DESCRIPTION
1) Remove `desktop_pixmap::put_screen` as it is redundant now
2) Make `desktop_pixmap::resize` and `desktop_pixmap::create_pixmap` receive screenshot dimensions
3) Big screens can be screenshoted by parts and mapped onto pixmap
4) TODO: Create a separate `.hpp` configuration file for user-defined constants