### PR TITLE
Send downsized RGBA pixmaps over sockets

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ CheckOptions:
   - { key: readability-identifier-naming.ClassCase,              value: lower_case }
   - { key: readability-identifier-naming.StructCase,             value: lower_case }
   - { key: readability-identifier-naming.TemplateParameterCase,  value: lower_case }
+  - { key: readability-identifier-naming.TypeTemplateParameterCase,  value: CamelCase }
   - { key: readability-identifier-naming.FunctionCase,           value: lower_case }
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
   - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gdb_history
+src/config.hpp
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gdb_history
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -pthread")
+
 add_executable(dexpo dexpo.cpp desktop_pixmap.cpp dexpo_socket.cpp drawable.cpp
                      window.cpp)
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -12,7 +12,7 @@ const int dexpo_padding = 10;
 // Highlight color
 // Red (0xFFFF0000) recommended
 const unsigned int dexpo_hlcolor = 0xFFFF0000;
-// Higlight border width
+// Highlight border width
 // Should not be less than 3 or more than 8
 // Otherwise it will be poorly visible or buggy
 const int dexpo_hlwidth = 3;
@@ -26,3 +26,5 @@ const int dexpo_y = 0;
 const unsigned int dexpo_outer_border = 0;
 // Desktop viewport
 const std::vector<uint32_t> dexpo_viewport = {};
+// Timeout at which screenshots will be made
+const int dexpo_screenshot_timeout = 3;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,9 +1,12 @@
 // Displayed Screenshot width.
 // Will be calculated based on height and screen ratio if set to zero
-const int dexpo_width = 500;
+#include <cstdint>
+#include <vector>
+
+const int dexpo_width = 0;
 // Displayed screenshot height.
 // Will be calculated based on width and screen ratio if set to zero
-const int dexpo_height = 0;
+const int dexpo_height = 300;
 // Displayed interval between screenshots
 const int dexpo_padding = 10;
 // Highlight color
@@ -17,7 +20,9 @@ const int dexpo_hlwidth = 3;
 // White (0xFFFFFFFF) recommended
 const unsigned int dexpo_bgcolor = 0xFFFFFFFF;
 // Coordinates of GUI's top left corner
-const int dexpo_x = 0;
+const int dexpo_x = 1080;
 const int dexpo_y = 0;
 // Border outside of GUI window
 const unsigned int dexpo_outer_border = 0;
+// Desktop viewport
+const std::vector<uint32_t> dexpo_viewport = {};

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,30 +1,65 @@
-// Displayed Screenshot width.
-// Will be calculated based on height and screen ratio if set to zero
 #include <cstdint>
 #include <vector>
 
+/*
+  Width of the screenshots that will be displayed
+  Will be calculated based on height and screen ratio if set to zero
+
+  Actual window width will be equal to dexpo_width + (dexpo_padding * 2)
+*/
 const int dexpo_width = 0;
-// Displayed screenshot height.
-// Will be calculated based on width and screen ratio if set to zero
-const int dexpo_height = 300;
-// Displayed interval between screenshots
-const int dexpo_padding = 10;
-// Highlight color
-// Red (0xFFFF0000) recommended
-const unsigned int dexpo_hlcolor = 0xFFFF0000;
-// Highlight border width
-// Should not be less than 3 or more than 8
-// Otherwise it will be poorly visible or buggy
+
+/*
+  Height of the screenshots that will be displayed
+  Will be calculated based on width and screen ratio if set to zero
+
+  Actual window height will be equal to dexpo_height + (dexpo_padding * 2)
+*/
+const int dexpo_height = 150;
+
+/*
+  Padding between the screenshots and window border
+*/
+const int dexpo_padding = 5;
+
+/*
+  Color of the border around preselected desktop
+*/
+const unsigned int dexpo_hlcolor = 0XFF662C28;
+
+/*
+  Width of the border around preselected desktop
+*/
 const int dexpo_hlwidth = 3;
-// Background color
-// White (0xFFFFFFFF) recommended
-const unsigned int dexpo_bgcolor = 0xFFFFFFFF;
-// Coordinates of GUI's top left corner
-const int dexpo_x = 1080;
+
+/*
+  Background color. TODO Alpha doesn't work
+*/
+const unsigned int dexpo_bgcolor = 0xAA525252;
+
+/*
+  Coordinates of dexpo's top left corner
+*/
+const int dexpo_x = 0;
 const int dexpo_y = 0;
-// Border outside of GUI window
+
+/*
+  Border outside of GUI window
+*/
 const unsigned int dexpo_outer_border = 0;
-// Desktop viewport
+
+/*
+  Desktop viewport
+
+  Top left coordinates of each of your desktops in the format
+  { x1, y1, x2, y2, x3, y3 } and so on
+
+  Should be set only if you have a DE or
+   _NET_DESKOP_VIEWPORT doesn't output coordinates of all desktops
+*/
 const std::vector<uint32_t> dexpo_viewport = {};
-// Timeout at which screenshots will be made
-const int dexpo_screenshot_timeout = 3;
+
+/*
+  Timeout at which screenshots will be made
+*/
+const float dexpo_screenshot_timeout = 10;

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -248,7 +248,7 @@ main ()
   while (running)
     {
       size_t c = size_t (get_current_desktop ());
-      if (c >= dexpo_viewport.size () / 2)
+      if (!dexpo_viewport.empty () && c >= dexpo_viewport.size () / 2)
         {
           throw std::runtime_error (
               "The amount of virtual desktops specified in the config does not "

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -211,8 +211,6 @@ main ()
   std::vector<dexpo_pixmap *> socket_pixmaps{};
   for (size_t i = 0; i < pixmaps.size (); i++)
     {
-      pixmaps[i].save_screen ();
-
       uint32_t pixmap_len
           = pixmaps[i].pixmap_width * pixmaps[i].pixmap_height * 4;
 
@@ -239,19 +237,19 @@ main ()
                              std::ref (socket_pixmaps),
                              std::ref (socket_pixmaps_lock));
 
-  sleep (10);
-  bool running = true;
+  int running = 10;
   while (running)
     {
       size_t c = size_t (get_current_desktop ());
 
       socket_pixmaps_lock.lock ();
       pixmaps[c].save_screen ();
-      memcpy (&socket_pixmaps[c]->pixmap, pixmaps[c].pixmap_ptr,
+      memcpy (socket_pixmaps[c]->pixmap, pixmaps[c].pixmap_ptr,
               socket_pixmaps[c]->pixmap_len);
       socket_pixmaps_lock.unlock ();
+      running--;
 
-      usleep (100000);
+      sleep (1);
     };
 
   return 0;

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -237,7 +237,7 @@ main ()
                              std::ref (socket_pixmaps),
                              std::ref (socket_pixmaps_lock));
 
-  int running = 10;
+  bool running = true;
   while (running)
     {
       size_t c = size_t (get_current_desktop ());
@@ -247,9 +247,8 @@ main ()
       memcpy (socket_pixmaps[c]->pixmap, pixmaps[c].pixmap_ptr,
               socket_pixmaps[c]->pixmap_len);
       socket_pixmaps_lock.unlock ();
-      running--;
 
-      sleep (1);
+      sleep (dexpo_screenshot_timeout);
     };
 
   return 0;

--- a/src/desktop_pixmap.cpp
+++ b/src/desktop_pixmap.cpp
@@ -1,5 +1,6 @@
 #include "desktop_pixmap.hpp"
 #include "config.hpp"
+#include <algorithm>
 #include <memory>
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
@@ -20,7 +21,7 @@ desktop_pixmap::desktop_pixmap (
 
   // Initializing non built-in types to zeros
   this->image_ptr = nullptr;
-  this->pixmap_id = 0;
+  this->pixmap_ptr = nullptr;
   this->length = 0;
 
   // Initialize graphic context if it doesn't exist
@@ -53,7 +54,7 @@ desktop_pixmap::desktop_pixmap (
 
 desktop_pixmap::~desktop_pixmap ()
 {
-  xcb_free_pixmap (drawable::c_, this->pixmap_id);
+  // xcb_free_pixmap (drawable::c_, this->pixmap_);
   // TODO Add separate class to manage graphic context's destructor
 }
 
@@ -63,7 +64,7 @@ desktop_pixmap::desktop_pixmap (const desktop_pixmap &src)
   this->image_ptr = src.image_ptr;
   this->length = src.length;
   this->name = src.name;
-  this->pixmap_id = src.pixmap_id;
+  this->pixmap_ptr = src.pixmap_ptr;
   this->pixmap_width = src.pixmap_width;
   this->pixmap_height = src.pixmap_height;
 }
@@ -123,22 +124,15 @@ desktop_pixmap::save_screen ()
       int target_height
           = int (float (image_height) / image_width * this->pixmap_width);
 
-      auto pixmap = std::make_unique<uint8_t[]> (this->length + 1);
-
-      resize (this->image_ptr, pixmap.get (), image_width, image_height,
-              target_width, target_height);
       this->length = uint (target_width * target_height * 4);
+      int target_height_offset
+          = int (float (image_height_offset) * pixmap_width / image_width);
 
-      xcb_put_image (drawable::c_, XCB_IMAGE_FORMAT_Z_PIXMAP,
-                     this->pixmap_id,             /* Pixmap to put image on */
-                     desktop_pixmap::gc_,         /* Graphic context */
-                     target_width, target_height, /* Dimensions */
-                     0,                           /* Destination X coordinate */
-                     image_height_offset,         /* Destination Y coordinate */
-                     0, drawable::screen_->root_depth,
-                     this->length, /* Image size in bytes */
-                     pixmap.get ());
+      uint32_t pixmap_offset
+          = uint32_t (target_height_offset * target_width * 4);
 
+      resize (this->image_ptr, this->pixmap_ptr + pixmap_offset, image_width,
+              image_height, target_width, target_height);
       i++;
     }
 }
@@ -196,8 +190,10 @@ desktop_pixmap::create_gc ()
 void
 desktop_pixmap::create_pixmap ()
 {
-  this->pixmap_id = xcb_generate_id (drawable::c_);
-  xcb_create_pixmap (drawable::c_, drawable::screen_->root_depth,
-                     this->pixmap_id, drawable::screen_->root,
-                     this->pixmap_width, this->pixmap_height);
+  // this->pixmap_id = xcb_generate_id (drawable::c_);
+  // xcb_create_pixmap (drawable::c_, drawable::screen_->root_depth,
+  //                    this->pixmap_id, drawable::screen_->root,
+  //                    this->pixmap_width, this->pixmap_height);
+  this->pixmap_ptr
+      = (uint8_t *)malloc (this->pixmap_width * this->pixmap_height * 4);
 }

--- a/src/desktop_pixmap.cpp
+++ b/src/desktop_pixmap.cpp
@@ -21,7 +21,6 @@ desktop_pixmap::desktop_pixmap (
 
   // Initializing non built-in types to zeros
   this->image_ptr = nullptr;
-  this->pixmap_ptr = nullptr;
   this->length = 0;
 
   // Initialize graphic context if it doesn't exist
@@ -64,7 +63,7 @@ desktop_pixmap::desktop_pixmap (const desktop_pixmap &src)
   this->image_ptr = src.image_ptr;
   this->length = src.length;
   this->name = src.name;
-  this->pixmap_ptr = src.pixmap_ptr;
+  this->pixmap = src.pixmap;
   this->pixmap_width = src.pixmap_width;
   this->pixmap_height = src.pixmap_height;
 }
@@ -131,15 +130,14 @@ desktop_pixmap::save_screen ()
       uint32_t pixmap_offset
           = uint32_t (target_height_offset * target_width * 4);
 
-      resize (this->image_ptr, this->pixmap_ptr + pixmap_offset, image_width,
-              image_height, target_width, target_height);
+      resize (this->image_ptr, this->pixmap.data () + pixmap_offset,
+              image_width, image_height, target_width, target_height);
       i++;
     }
 }
 
 /**
  * Definitely copied. Looks like I'm too retarded to code this myself.
- * I have done custom resize! You killed it.
  * https://stackoverflow.com/questions/28566290
  *
  * TODO Optimize and fix warnings, comment on names, add anti aliasing
@@ -191,6 +189,5 @@ desktop_pixmap::create_gc ()
 void
 desktop_pixmap::create_pixmap ()
 {
-  this->pixmap_ptr
-      = (uint8_t *)malloc (this->pixmap_width * this->pixmap_height * 4);
+  this->pixmap.resize (this->pixmap_width * this->pixmap_height * 4);
 }

--- a/src/desktop_pixmap.hpp
+++ b/src/desktop_pixmap.hpp
@@ -3,6 +3,7 @@
 
 #include "drawable.hpp"
 #include <string>
+#include <vector>
 #include <xcb/xproto.h>
 
 enum pixmap_format
@@ -21,9 +22,9 @@ public:
   uint8_t *image_ptr;                   ///< Pointer to the image structure.
   uint32_t length;                      ///< Length of the XImage data structure
   std::string name;                     ///< _NET_WM_NAME of display
-  uint8_t *pixmap_ptr;    ///< Constant id for the screenshot's pixmap
-  uint16_t pixmap_width;  ///< Width of the pixmap that stores screenshot
-  uint16_t pixmap_height; ///< Height of the pixmap that stores screenshot
+  std::vector<uint8_t> pixmap; ///< Constant id for the screenshot's pixmap
+  uint16_t pixmap_width;       ///< Width of the pixmap that stores screenshot
+  uint16_t pixmap_height;      ///< Height of the pixmap that stores screenshot
 
   desktop_pixmap (
       int16_t x,              ///< x coordinate of the top left corner

--- a/src/desktop_pixmap.hpp
+++ b/src/desktop_pixmap.hpp
@@ -21,7 +21,7 @@ public:
   uint8_t *image_ptr;                   ///< Pointer to the image structure.
   uint32_t length;                      ///< Length of the XImage data structure
   std::string name;                     ///< _NET_WM_NAME of display
-  xcb_pixmap_t pixmap_id; ///< Constant id for the screenshot's pixmap
+  uint8_t *pixmap_ptr;    ///< Constant id for the screenshot's pixmap
   uint16_t pixmap_width;  ///< Width of the pixmap that stores screenshot
   uint16_t pixmap_height; ///< Height of the pixmap that stores screenshot
 

--- a/src/dexpo.cpp
+++ b/src/dexpo.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <vector>
 
+// TODO Holy fuck we need to fix this burning shit
 desktop_pixmap d0 (0, 0, 1080, 1920, "");
 
 int
@@ -25,7 +26,7 @@ main ()
           += 2 * dexpo_padding; // Add the paddng at both sizes of interface
       for (const auto &dexpo_pixmap : v)
         {
-          conf_width += dexpo_pixmap->width;
+          conf_width += dexpo_pixmap.width;
           conf_width += dexpo_padding;
         }
     }
@@ -36,7 +37,7 @@ main ()
           += 2 * dexpo_padding; // Add the paddng at both sizes of interface
       for (const auto &dexpo_pixmap : v)
         {
-          conf_height += dexpo_pixmap->height;
+          conf_height += dexpo_pixmap.height;
           conf_height += dexpo_padding;
         }
     };
@@ -44,7 +45,7 @@ main ()
   window w (dexpo_x, dexpo_y, conf_width, conf_height);
   w.pixmaps = v;
   // Mapping pixmap onto window
-  xcb_generic_event_t *event;
+  xcb_generic_event_t *event = nullptr;
   while ((event = xcb_wait_for_event (window::c_)))
     {
       switch (event->response_type & ~0x80)
@@ -103,17 +104,17 @@ main ()
                 if (dexpo_height == 0)
                   {
                     if ((mn->event_x - dexpo_padding > 0)
-                        and (mn->event_x - dexpo_padding < dexpo_pixmap->width)
+                        and (mn->event_x - dexpo_padding < dexpo_pixmap.width)
                         and (mn->event_y
                                  - w.get_screen_position (
-                                     dexpo_pixmap->desktop_number)
+                                     dexpo_pixmap.desktop_number)
                              > 0)
                         and (mn->event_y
                                  - w.get_screen_position (
-                                     dexpo_pixmap->desktop_number)
-                             < dexpo_pixmap->height))
+                                     dexpo_pixmap.desktop_number)
+                             < dexpo_pixmap.height))
                       {
-                        det = dexpo_pixmap->desktop_number;
+                        det = dexpo_pixmap.desktop_number;
                         break;
                       }
                   }
@@ -121,17 +122,16 @@ main ()
                   {
                     if ((mn->event_x
                              - w.get_screen_position (
-                                 dexpo_pixmap->desktop_number)
+                                 dexpo_pixmap.desktop_number)
                          > 0)
                         and (mn->event_x
                                  - w.get_screen_position (
-                                     dexpo_pixmap->desktop_number)
-                             < dexpo_pixmap->width)
+                                     dexpo_pixmap.desktop_number)
+                             < dexpo_pixmap.width)
                         and (mn->event_y - dexpo_padding > 0)
-                        and (mn->event_y - dexpo_padding
-                             < dexpo_pixmap->height))
+                        and (mn->event_y - dexpo_padding < dexpo_pixmap.height))
                       {
-                        det = dexpo_pixmap->desktop_number;
+                        det = dexpo_pixmap.desktop_number;
                         break;
                       }
                   }

--- a/src/dexpo_socket.cpp
+++ b/src/dexpo_socket.cpp
@@ -177,7 +177,7 @@ dexpo_socket::get_pixmaps () const
  * and sends pixmaps one by one in return
  */
 void
-dexpo_socket::send_pixmaps_on_event (const std::vector<dexpo_pixmap> pixmaps,
+dexpo_socket::send_pixmaps_on_event (const std::vector<dexpo_pixmap> &pixmaps,
                                      std::mutex &pixmaps_lock) const
 {
   int data_fd = 0; // Socket file descriptor

--- a/src/dexpo_socket.cpp
+++ b/src/dexpo_socket.cpp
@@ -69,7 +69,6 @@ dexpo_socket::dexpo_socket ()
       // This should be run only for the first connection, as socket may not
       // exist then.
       // And should not be run when there are active connections to the socket
-      std::cerr << e.what () << std::endl;
 
       unlink (SOCKET_PATH); // Remove existing socket
 
@@ -135,15 +134,13 @@ dexpo_socket::get_pixmaps () const
  */
 void
 dexpo_socket::send_pixmaps_on_event (const std::vector<dexpo_pixmap *> &pixmaps,
-                                     std::mutex &pixmaps_lock)
+                                     std::mutex &pixmaps_lock) const
 {
-  auto data_fd = accept (this->fd, nullptr, nullptr); // Anonymous socket
-  char cmd = -1;
+  int data_fd = 0; // Socket file descriptor
 
-  this->running = true; // Can later turn off the loop
-
-  while (this->running) // FIXME This loop exit is ugly
+  while ((data_fd = accept (this->fd, nullptr, nullptr)))
     {
+      char cmd = -1;
       if (read (data_fd, &cmd, 1) == kRequestPixmaps) // Listen for the command
         {
           // Lock pixmaps to prevent race condition when reading and writing

--- a/src/dexpo_socket.cpp
+++ b/src/dexpo_socket.cpp
@@ -103,10 +103,8 @@ dexpo_socket::get_pixmaps () const
   std::vector<dexpo_pixmap *>
       pixmap_array; // Pixmap array that will be returned
 
-  size_t num = 0;
+  size_t num = 0; // Amount of pixmaps that will be received
   auto rcv_bytes = read (this->fd, &num, sizeof (num));
-
-  std::cout << num << std::endl;
   is<read_error> (rcv_bytes);
 
   for (; num > 0; num--) // Read `num` pixmaps from socket
@@ -115,8 +113,6 @@ dexpo_socket::get_pixmaps () const
 
       rcv_bytes = read (this->fd, p, sizeof (dexpo_pixmap));
       is<read_error> (rcv_bytes);
-
-      std::cout << p->pixmap_len << std::endl;
 
       uint8_t *pixmap_ptr = (uint8_t *)malloc (p->pixmap_len);
       rcv_bytes = read (this->fd, pixmap_ptr, p->pixmap_len);
@@ -138,7 +134,7 @@ dexpo_socket::send_pixmaps_on_event (const std::vector<dexpo_pixmap *> &pixmaps,
 {
   int data_fd = 0; // Socket file descriptor
 
-  while ((data_fd = accept (this->fd, nullptr, nullptr)))
+  while ((data_fd = accept (this->fd, nullptr, nullptr)) && this->running)
     {
       char cmd = -1;
       if (read (data_fd, &cmd, 1) == kRequestPixmaps) // Listen for the command

--- a/src/dexpo_socket.cpp
+++ b/src/dexpo_socket.cpp
@@ -51,7 +51,7 @@ dexpo_socket::dexpo_socket ()
   auto *sock_addr = reinterpret_cast<struct sockaddr *> (&sock_name);
 
   // XXX Make socket abstract
-  // sock_name.sun_path[0] = '\0';
+  sock_name.sun_path[0] = '\0';
 
   int s = 0; // Return status of functions to check for errors
   try

--- a/src/dexpo_socket.hpp
+++ b/src/dexpo_socket.hpp
@@ -49,7 +49,7 @@ public:
   dexpo_socket &operator= (dexpo_socket &&other) = delete;
 
   std::vector<dexpo_pixmap> get_pixmaps () const;
-  void send_pixmaps_on_event (const std::vector<dexpo_pixmap>,
+  void send_pixmaps_on_event (const std::vector<dexpo_pixmap> &,
                               std::mutex &pixmaps_lock) const;
   void server () const;
 };

--- a/src/dexpo_socket.hpp
+++ b/src/dexpo_socket.hpp
@@ -20,8 +20,9 @@ struct dexpo_pixmap
   int desktop_number; // _NET_CURRENT_DESKTOP
   uint16_t width;
   uint16_t height;
-  xcb_pixmap_t id; ///< Id of the screenshot's pixmap
+  uint32_t pixmap_len;
   char name[DESKTOP_NAME_MAX_LEN];
+  uint8_t *pixmap; ///< Pixmap in RBGA format
 };
 
 /**
@@ -47,8 +48,8 @@ public:
   dexpo_socket &operator= (const dexpo_socket &other) = delete;
   dexpo_socket &operator= (dexpo_socket &&other) = delete;
 
-  std::vector<dexpo_pixmap> get_pixmaps () const;
-  void send_pixmaps_on_event (const std::vector<dexpo_pixmap> &,
+  std::vector<dexpo_pixmap *> get_pixmaps () const;
+  void send_pixmaps_on_event (const std::vector<dexpo_pixmap *> &,
                               std::mutex &pixmaps_lock);
   void server () const;
 };

--- a/src/dexpo_socket.hpp
+++ b/src/dexpo_socket.hpp
@@ -50,7 +50,7 @@ public:
 
   std::vector<dexpo_pixmap *> get_pixmaps () const;
   void send_pixmaps_on_event (const std::vector<dexpo_pixmap *> &,
-                              std::mutex &pixmaps_lock);
+                              std::mutex &pixmaps_lock) const;
   void server () const;
 };
 

--- a/src/dexpo_socket.hpp
+++ b/src/dexpo_socket.hpp
@@ -36,8 +36,8 @@ enum daemon_event
 class dexpo_socket
 {
 public:
-  int fd;                    ///< Socket File Descriptor
-  std::atomic<bool> running; ///< Thread status
+  int fd;                           ///< Socket File Descriptor
+  std::atomic<bool> running = true; ///< Thread status
 
   dexpo_socket ();
   ~dexpo_socket ();

--- a/src/dexpo_socket.hpp
+++ b/src/dexpo_socket.hpp
@@ -22,7 +22,7 @@ struct dexpo_pixmap
   uint16_t height;
   uint32_t pixmap_len;
   char name[DESKTOP_NAME_MAX_LEN];
-  uint8_t *pixmap; ///< Pixmap in RBGA format
+  std::vector<uint8_t> pixmap; ///< Pixmap in RBGA format
 };
 
 /**
@@ -48,8 +48,8 @@ public:
   dexpo_socket &operator= (const dexpo_socket &other) = delete;
   dexpo_socket &operator= (dexpo_socket &&other) = delete;
 
-  std::vector<dexpo_pixmap *> get_pixmaps () const;
-  void send_pixmaps_on_event (const std::vector<dexpo_pixmap *> &,
+  std::vector<dexpo_pixmap> get_pixmaps () const;
+  void send_pixmaps_on_event (const std::vector<dexpo_pixmap>,
                               std::mutex &pixmaps_lock) const;
   void server () const;
 };

--- a/src/dexpo_socket.hpp
+++ b/src/dexpo_socket.hpp
@@ -9,7 +9,7 @@
 #include <sys/socket.h>
 #include <vector>
 
-#define SOCKET_PATH "/tmp/dexpo.socket"
+#define SOCKET_PATH "@/tmp/dexpo.socket"
 #define DESKTOP_NAME_MAX_LEN 255
 
 /**

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -75,13 +75,13 @@ window::draw_gui ()
           xcb_put_image (desktop_pixmap::c_, XCB_IMAGE_FORMAT_Z_PIXMAP,
                          this->id,            /* Pixmap to put image on */
                          desktop_pixmap::gc_, /* Graphic context */
-                         pixmap->width, pixmap->height, /* Dimensions */
+                         pixmap.width, pixmap.height, /* Dimensions */
                          act_width,     /* Destination X coordinate */
                          dexpo_padding, /* Destination Y coordinate */
                          0, drawable::screen_->root_depth,
-                         pixmap->pixmap_len, /* Image size in bytes */
-                         pixmap->pixmap);
-          act_width += pixmap->width;
+                         pixmap.pixmap_len, /* Image size in bytes */
+                         pixmap.pixmap.data ());
+          act_width += pixmap.width;
           act_width += dexpo_padding;
         };
     }
@@ -93,13 +93,13 @@ window::draw_gui ()
           xcb_put_image (desktop_pixmap::c_, XCB_IMAGE_FORMAT_Z_PIXMAP,
                          this->id,            /* Pixmap to put image on */
                          desktop_pixmap::gc_, /* Graphic context */
-                         pixmap->width, pixmap->height, /* Dimensions */
+                         pixmap.width, pixmap.height, /* Dimensions */
                          dexpo_padding, /* Destination X coordinate */
                          act_height,    /* Destination Y coordinate */
                          0, drawable::screen_->root_depth,
-                         pixmap->pixmap_len, /* Image size in bytes */
-                         pixmap->pixmap);
-          act_height += pixmap->height;
+                         pixmap.pixmap_len, /* Image size in bytes */
+                         pixmap.pixmap.data ());
+          act_height += pixmap.height;
           act_height += dexpo_padding;
         };
     }
@@ -114,16 +114,16 @@ window::get_screen_position (int desktop_number)
   for (const auto &dexpo_pixmap : this->pixmaps)
     {
       // Estimating all space before the screenshot we search
-      if (dexpo_pixmap->desktop_number < desktop_number)
+      if (dexpo_pixmap.desktop_number < desktop_number)
         {
           coord += dexpo_padding;
           if (dexpo_height == 0)
             {
-              coord += dexpo_pixmap->height;
+              coord += dexpo_pixmap.height;
             }
           else if (dexpo_width == 0)
             {
-              coord += dexpo_pixmap->width;
+              coord += dexpo_pixmap.width;
             }
         }
       else
@@ -141,8 +141,8 @@ window::highlight_window (int desktop_number, uint32_t color)
   int16_t y = dexpo_padding;
   uint32_t values[1]; // mask for changing border's color
 
-  uint16_t width = this->pixmaps[size_t (desktop_number)]->width;
-  uint16_t height = this->pixmaps[size_t (desktop_number)]->height;
+  uint16_t width = this->pixmaps[size_t (desktop_number)].width;
+  uint16_t height = this->pixmaps[size_t (desktop_number)].height;
 
   if (dexpo_height == 0)
     {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -62,19 +62,19 @@ window::get_screen_position (int desktop_number)
   // As all screenshots have at least one common coordinate of corner, we need
   // to find only the second one
   int coord = dexpo_padding;
-  for (const auto &dexpo_pixmap : pixmaps)
+  for (const auto &dexpo_pixmap : this->pixmaps)
     {
       // Estimating all space before the screenshot we search
-      if (dexpo_pixmap.desktop_number < desktop_number)
+      if (dexpo_pixmap->desktop_number < desktop_number)
         {
           coord += dexpo_padding;
           if (dexpo_height == 0)
             {
-              coord += dexpo_pixmap.height;
+              coord += dexpo_pixmap->height;
             }
           else if (dexpo_width == 0)
             {
-              coord += dexpo_pixmap.width;
+              coord += dexpo_pixmap->width;
             }
         }
       else
@@ -92,8 +92,8 @@ window::highlight_window (int desktop_number, uint32_t color)
   int16_t y = dexpo_padding;
   uint32_t values[1]; // mask for changing border's color
 
-  uint16_t width = this->pixmaps[size_t (desktop_number)].width;
-  uint16_t height = this->pixmaps[size_t (desktop_number)].height;
+  uint16_t width = this->pixmaps[size_t (desktop_number)]->width;
+  uint16_t height = this->pixmaps[size_t (desktop_number)]->height;
 
   if (dexpo_height == 0)
     {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -13,7 +13,7 @@ window::window (const int16_t x,       ///< x coordinate of the top left corner
 {
   this->b_width = dexpo_outer_border;
   this->id = xcb_generate_id (drawable::c_);
-  this->highlighted = 0;
+  this->highlighted = 0; // Id of the preselected desktop
   create_window ();
 }
 
@@ -35,7 +35,7 @@ window::create_window ()
               | XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_KEY_RELEASE
               | XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_POINTER_MOTION
               | XCB_EVENT_MASK_LEAVE_WINDOW | XCB_EVENT_MASK_ENTER_WINDOW;
-  ;
+
   values[2] = XCB_STACK_MODE_ABOVE; // Places created window on top
   xcb_create_window (window::c_, /* Connection, separate from one of daemon */
                      XCB_COPY_FROM_PARENT,          /* depth (same as root)*/

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -16,7 +16,7 @@ public:
   inline static xcb_gcontext_t gc_; ///< Graphic context
   uint32_t id;                      // Identificator for Window
   uint16_t b_width; // Border width NOTE: Maybe it could be changed to constant
-  std::vector<dexpo_pixmap *> pixmaps;
+  std::vector<dexpo_pixmap> pixmaps;
   int highlighted;
   // TODO: Add masks for events
 

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -16,7 +16,7 @@ public:
   inline static xcb_gcontext_t gc_; ///< Graphic context
   uint32_t id;                      // Identificator for Window
   uint16_t b_width; // Border width NOTE: Maybe it could be changed to constant
-  std::vector<dexpo_pixmap> pixmaps;
+  std::vector<dexpo_pixmap *> pixmaps;
   // TODO: Add masks for events
 
   // The same as for DesktopPixmap


### PR DESCRIPTION
Turns out pixmap_ids are local to the xcb_connection_t and can't be shared across multiple connections.
The only way to transfer pixmaps between daemon and gui is to send downsized pixmaps over sockets. Thankfully it's really fast.

To be closing #3 

TODO:
- [x] Utilize smart memory handles with vectors
- [x] Fix the error with messed up socket reads