### PR TITLE
Link common files as an Object Library. Closes #19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,3 +46,6 @@ if(ENABLE_TESTING)
 endif()
 
 add_subdirectory(src)
+
+add_library(dexpo_lib OBJECT src/desktop.cpp src/drawable.cpp src/socket.cpp
+                             src/window.cpp src/xcb_util.cpp)

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -1,8 +1,8 @@
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+  message(STATUS "Setting build type to 'Release' as none was specified.")
   set(CMAKE_BUILD_TYPE
-      RelWithDebInfo
+      Release
       CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui, ccmake
   set_property(
@@ -17,7 +17,7 @@ endif()
 # Generate compile_commands.json to make it easier to work with clang based tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-option(ENABLE_IPO "Enable Interprocedural Optimization, aka Link Time Optimization (LTO)" OFF)
+option(ENABLE_IPO "Enable Interprocedural Optimization, aka Link Time Optimization (LTO)" ON)
 
 if(ENABLE_IPO)
   include(CheckIPOSupported)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,17 +1,15 @@
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -pthread")
 
-add_executable(dexpo dexpo.cpp desktop.cpp socket.cpp drawable.cpp xcb_util.cpp
-                     window.cpp)
+add_executable(dexpo dexpo.cpp)
 
-add_executable(daemon daemon.cpp desktop.cpp socket.cpp drawable.cpp
-                      xcb_util.cpp)
+add_executable(daemon daemon.cpp)
 
 target_link_libraries(
   dexpo
-  PRIVATE project_options project_warnings
+  PRIVATE dexpo_lib project_options project_warnings
   PUBLIC xcb xcb-randr)
 
 target_link_libraries(
   daemon
-  PRIVATE project_options project_warnings
+  PRIVATE dexpo_lib project_options project_warnings
   PUBLIC xcb xcb-randr)


### PR DESCRIPTION
I do not 100% understand the terminology, but it looks like [making an object library](https://github.com/cyberVirtua/dexpo/blob/cmake-link-common/CMakeLists.txt#L50) out of my `.cpp` files lets the linker pick only the required functions. 
And LTO even further optimizes it, dropping everything unused with extreme precision. To the point where it could know a given else block can't run.