### PR TITLE
Extend configurability of dxp's position on screen

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 using color = const uint32_t;
@@ -17,8 +18,31 @@ using color = const uint32_t;
 const uint dxp_width = 0;
 const uint dxp_height = 150;
 
-const int16_t dxp_x = 0; ///< X coordinate of window's top left corner
-const int16_t dxp_y = 0; ///< Y coordinate of window's top left corner
+///
+/// Name of the monitor to put window on. Will use primary if unset.
+///
+const std::string dxp_monitor_name = "DVI-D-0";
+
+///
+/// Prepending minus to the coordinate value will switch the corner side:
+///
+/// +x, +y: top left corner
+/// +x, -y: bottom left corner
+/// -x, +y: top right corner
+/// -x, -y: bottom right corner
+///
+/// Coordinates are relative to the specified monitor.
+///
+/// NOTE: To specify -0, write = -0.0
+///
+const float dxp_x = -10; ///< X coordinate of window's corner
+const float dxp_y = -22; ///< Y coordinate of window's corner
+
+///
+/// If centering is enabled, corresponding coordinate will be ignored
+///
+const bool dxp_center_x = false; ///< Center dxp on the monitor horizontally
+const bool dxp_center_y = false; ///< Center dxp on the monitor vertically
 
 const uint16_t dxp_padding = 3; ///< Padding around the screenshots
 
@@ -33,8 +57,8 @@ const uint dxp_border_width = 0; ///< dxp window border
 ///
 /// How often to take screenshots.
 ///
-/// Recommended value is 10 seconds
-//
+/// Recommended value is 10 seconds.
+///
 /// NOTE: Setting timeout to values below 5 ms may severely increase CPU load.
 ///
 const auto dxp_screenshot_period = std::chrono::seconds (1);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -35,13 +35,13 @@ const std::string dxp_monitor_name = "DVI-D-0";
 ///
 /// NOTE: To specify -0, write = -0.0
 ///
-const float dxp_x = -10; ///< X coordinate of window's corner
-const float dxp_y = -22; ///< Y coordinate of window's corner
+const float dxp_x = 0; ///< X coordinate of window's corner
+const float dxp_y = 0; ///< Y coordinate of window's corner
 
 ///
 /// If centering is enabled, corresponding coordinate will be ignored
 ///
-const bool dxp_center_x = false; ///< Center dxp on the monitor horizontally
+const bool dxp_center_x = true;  ///< Center dxp on the monitor horizontally
 const bool dxp_center_y = false; ///< Center dxp on the monitor vertically
 
 const uint16_t dxp_padding = 3; ///< Padding around the screenshots

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -21,7 +21,7 @@ const uint dxp_height = 150;
 ///
 /// Name of the monitor to put window on. Will use primary if unset.
 ///
-const std::string dxp_monitor_name = "DVI-D-0";
+const std::string dxp_monitor_name = "";
 
 ///
 /// Prepending minus to the coordinate value will switch the corner side:

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -21,3 +21,5 @@ drawable::drawable (const int16_t x,  ///< x coordinate of the top left corner
       drawable::root_ = screen_->root;
     }
 }
+
+drawable::drawable () : drawable (0, 0, 0, 0) {}

--- a/src/drawable.hpp
+++ b/src/drawable.hpp
@@ -17,6 +17,8 @@ public:
   uint width;
   uint height;
 
+  /// Initialize static variables, set x, y, width, height to zero
+  drawable ();
   drawable (int16_t x,  ///< x coordinate of the top left corner
             int16_t y,  ///< y coordinate of the top left corner
             uint width, ///< Width of the display

--- a/src/dxp.cpp
+++ b/src/dxp.cpp
@@ -22,7 +22,7 @@ main ()
       dxp_socket client;
       auto v = client.get_desktops ();
 
-      window w (dxp_x, dxp_y, v);
+      window w (v);
 
       // Handling incoming events
       // Freeing it with free() is not specified in the docs, but it works

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -74,14 +74,28 @@ window::set_window_dimensions ()
     }
 
   // Set window coordinates based on config values
-  x = dxp_x >= 0 && !std::signbit (dxp_x) // signbit is to handle negative zero
-          ? dxp_x
-          : dxp_monitor.width - this->width - std::abs (dxp_x);
-  x += dxp_monitor.x; // Add monitor's offset
-
-  y += dxp_y >= 0 && !std::signbit (dxp_y)
-           ? dxp_y
-           : dxp_monitor.height - this->height - std::abs (dxp_y);
+  if (dxp_center_x)
+    {
+      x = dxp_monitor.width / 2 - this->width / 2;
+    }
+  else
+    {
+      x = dxp_x >= 0 && !std::signbit (dxp_x) // handle negative zero
+              ? dxp_x
+              : dxp_monitor.width - this->width - std::abs (dxp_x);
+    }
+  if (dxp_center_y)
+    {
+      y = dxp_monitor.height / 2 - this->height / 2;
+    }
+  else
+    {
+      y += dxp_y >= 0 && !std::signbit (dxp_y)
+               ? dxp_y
+               : dxp_monitor.height - this->height - std::abs (dxp_y);
+    }
+  // Add monitor offsets
+  x += dxp_monitor.x;
   y += dxp_monitor.y;
 };
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2,16 +2,16 @@
 #include "config.hpp"
 #include "drawable.hpp"
 #include "xcb_util.hpp"
+#include <cmath>
+#include <iostream>
 #include <vector>
 #include <xcb/xproto.h>
 
 constexpr bool k_horizontal_stacking = (dxp_width == 0);
 constexpr bool k_vertical_stacking = (dxp_height == 0);
 
-window::window (const int16_t x, ///< x coordinate of the top left corner
-                const int16_t y, ///< y coordinate of the top left corner
-                const std::vector<dxp_socket_desktop> &desktops)
-    : drawable (x, y, 0, 0) // Width and height will be calculated from config
+window::window (const std::vector<dxp_socket_desktop> &desktops)
+    : drawable (0, 0, 0, 0) // Width and height will be calculated from config
 {
   this->xcb_id = xcb_generate_id (drawable::c_);
   this->desktops = desktops;
@@ -45,6 +45,44 @@ window::set_window_dimensions ()
 
   this->width += k_vertical_stacking ? constant + dxp_width : dynamic;
   this->height += k_horizontal_stacking ? constant + dxp_height : dynamic;
+
+  /* Determine what monitor to draw window on */
+  monitor_info dxp_monitor{ 0, 0, 0, 0, "" };
+
+  if (dxp_monitor_name.empty ()) // Use primary if name is not specified
+    {
+      dxp_monitor = get_monitor_primary (window::c_, window::root_);
+    }
+  else // Get coordinates of the monitor that was specified in the config
+    {
+      auto monitors = get_monitors (window::c_, window::root_);
+      for (const auto &m : monitors)
+        {
+          if (m.name == dxp_monitor_name)
+            {
+              dxp_monitor = m;
+              break;
+            }
+        }
+      if (dxp_monitor.height == 0) // If target monitor was not found
+        {
+          std::cerr << "Monitor with name \"" << dxp_monitor_name
+                    << "\" was not found. Using primary monitor" << std::endl;
+
+          dxp_monitor = get_monitor_primary (window::c_, window::root_);
+        }
+    }
+
+  // Set window coordinates based on config values
+  x = dxp_x >= 0 && !std::signbit (dxp_x) // signbit is to handle negative zero
+          ? dxp_x
+          : dxp_monitor.width - this->width - std::abs (dxp_x);
+  x += dxp_monitor.x; // Add monitor's offset
+
+  y += dxp_y >= 0 && !std::signbit (dxp_y)
+           ? dxp_y
+           : dxp_monitor.height - this->height - std::abs (dxp_y);
+  y += dxp_monitor.y;
 };
 
 /**
@@ -73,7 +111,7 @@ window::create_window ()
                      window::root_,                 /* parent window */
                      this->x, this->y,              /* x, y */
                      this->width, this->height,     /* width, height */
-                     dxp_border_width,            /* border_width */
+                     dxp_border_width,              /* border_width */
                      XCB_WINDOW_CLASS_INPUT_OUTPUT, /* class */
                      window::screen_->root_visual,  /* visual */
                      mask, &mask_values);           /* masks, not used yet */
@@ -168,8 +206,8 @@ window::get_hover_desktop (int16_t x, int16_t y)
           // Check if cursor is inside of the desktop
           if (x >= dxp_padding &&           // Not to the left
               x <= d.width + dxp_padding && // Not to the right
-              y >= desktop_y &&               // Not above
-              y <= d.height + desktop_y)      // Not below
+              y >= desktop_y &&             // Not above
+              y <= d.height + desktop_y)    // Not below
             {
               return d.id;
             }
@@ -178,8 +216,8 @@ window::get_hover_desktop (int16_t x, int16_t y)
         {
           auto desktop_x = get_desktop_coord (d.id);
           // Check if cursor is inside of the desktop
-          if (x >= desktop_x &&              // To the right of left border
-              x <= d.width + desktop_x &&    // To the left of right border
+          if (x >= desktop_x &&            // To the right of left border
+              x <= d.width + desktop_x &&  // To the left of right border
               y >= dxp_padding &&          // Not above
               y <= d.height + dxp_padding) // Not below
             {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -11,7 +11,7 @@ constexpr bool k_horizontal_stacking = (dxp_width == 0);
 constexpr bool k_vertical_stacking = (dxp_height == 0);
 
 window::window (const std::vector<dxp_socket_desktop> &desktops)
-    : drawable (0, 0, 0, 0) // Width and height will be calculated from config
+    : drawable () // x, y, widht, height will be set later based on config
 {
   this->xcb_id = xcb_generate_id (drawable::c_);
   this->desktops = desktops;

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -17,9 +17,7 @@ public:
   std::vector<dxp_socket_desktop> desktops; ///< Desktops received from daemon
   uint pres;                                ///< id of the preselected desktop
 
-  window (int16_t x, ///< x coordinate of the top left corner
-          int16_t y, ///< y coordinate of the top left corner
-          const std::vector<dxp_socket_desktop> &desktops);
+  explicit window (const std::vector<dxp_socket_desktop> &desktops);
   ~window ();
 
   // Explicitly deleting unused constructors to comply with rule of five

--- a/src/xcb_util.cpp
+++ b/src/xcb_util.cpp
@@ -1,6 +1,7 @@
 #include "xcb_util.hpp"
 #include "config.hpp"
 #include "window.hpp"
+#include <cstdint>
 #include <cstring>
 #include <xcb/xcb.h>
 
@@ -104,6 +105,9 @@ get_monitors (xcb_connection_t *c, xcb_window_t root)
         {
           continue;
         }
+      std::string name (reinterpret_cast<char *> (
+                            xcb_randr_get_output_info_name (output.get ())),
+                        output->name_len);
 
       auto crtc = xcb_unique_ptr<xcb_randr_get_crtc_info_reply_t> (
           xcb_randr_get_crtc_info_reply (
@@ -111,10 +115,43 @@ get_monitors (xcb_connection_t *c, xcb_window_t root)
               &e));
       check (e, "XCB error while getting randr info reply");
 
-      monitor_info m{ crtc->x, crtc->y, crtc->width, crtc->height };
+      monitor_info m{ crtc->x, crtc->y, crtc->width, crtc->height, name };
       monitors.push_back (m);
     }
   return monitors;
+}
+
+/**
+ * Get crtc of the primary monitor.
+ *
+ * NOTE: Returned monitor_info.name is unsed as it is unused.
+ */
+monitor_info
+get_monitor_primary (xcb_connection_t *c, xcb_window_t root)
+{
+
+  xcb_generic_error_t *e = nullptr;
+  auto primary_cookie = xcb_randr_get_output_primary (c, root);
+
+  auto primary = xcb_unique_ptr<xcb_randr_get_output_primary_reply_t> (
+      xcb_randr_get_output_primary_reply (c, primary_cookie, &e));
+  check (e, "XCB error while getting primary monitor reply");
+
+  auto primary_info
+      = xcb_randr_get_output_info (c, primary->output, XCB_CURRENT_TIME);
+
+  auto primary_output = xcb_unique_ptr<xcb_randr_get_output_info_reply_t> (
+      xcb_randr_get_output_info_reply (c, primary_info, &e));
+  check (e, "XCB error while getting randr info reply");
+
+  auto crtc = xcb_unique_ptr<xcb_randr_get_crtc_info_reply_t> (
+      xcb_randr_get_crtc_info_reply (
+          c,
+          xcb_randr_get_crtc_info (c, primary_output->crtc, XCB_CURRENT_TIME),
+          &e));
+  check (e, "XCB error while getting randr info reply");
+
+  return monitor_info{ crtc->x, crtc->y, crtc->width, crtc->height, "" };
 }
 
 /**

--- a/src/xcb_util.cpp
+++ b/src/xcb_util.cpp
@@ -122,9 +122,7 @@ get_monitors (xcb_connection_t *c, xcb_window_t root)
 }
 
 /**
- * Get crtc of the primary monitor.
- *
- * NOTE: Returned monitor_info.name is unsed as it is unused.
+ * Get monitor_info of the primary monitor.
  */
 monitor_info
 get_monitor_primary (xcb_connection_t *c, xcb_window_t root)

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -82,9 +82,7 @@ std::vector<uint32_t> get_property_value (xcb_connection_t *c,
 std::vector<monitor_info> get_monitors (xcb_connection_t *c, xcb_window_t root);
 
 /**
- * Get crtc of the primary monitor.
- *
- * NOTE: Returned monitor_info.name is unsed as it is unused.
+ * Get monitor_info of the primary monitor
  */
 monitor_info get_monitor_primary (xcb_connection_t *c, xcb_window_t root);
 

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -31,6 +31,7 @@ struct monitor_info
   int y;
   uint width;
   uint height;
+  std::string name;
 };
 
 /**
@@ -79,6 +80,13 @@ std::vector<uint32_t> get_property_value (xcb_connection_t *c,
  * Get monitor_info for each connected monitor
  */
 std::vector<monitor_info> get_monitors (xcb_connection_t *c, xcb_window_t root);
+
+/**
+ * Get crtc of the primary monitor.
+ *
+ * NOTE: Returned monitor_info.name is unsed as it is unused.
+ */
+monitor_info get_monitor_primary (xcb_connection_t *c, xcb_window_t root);
 
 /**
  * Get an array of desktop_info.


### PR DESCRIPTION
- dxp can be placed in any of the moniotr's corners
- Specify what monitor to put dxp on with `dxp_monitor_name`
- `dxp_monitor` defaults to primary monitor with `get_monitor_primary()`
- dxp can be centered both vertically and horizontally

Closes #14