### PR TITLE
Config option to replace screenshots with window geometries outlines

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -22,7 +22,7 @@ using keys = std::array<std::string_view, keys_size>;
 /// Actual window width will be equal to dxp_width + (dxp_padding * 2)
 ///
 const uint dxp_width = 0;
-const uint dxp_height = 150;
+const uint dxp_height = 175;
 
 ///
 /// Name of the monitor to put window on. Will use primary if unset.
@@ -48,7 +48,7 @@ const float dxp_y = 0; ///< Y coordinate of window's corner
 /// If centering is enabled, corresponding coordinate will be ignored
 ///
 const bool dxp_center_x = true;  ///< Center dxp on the monitor horizontally
-const bool dxp_center_y = false; ///< Center dxp on the monitor vertically
+const bool dxp_center_y = true; ///< Center dxp on the monitor vertically
 
 const uint16_t dxp_padding = 3; ///< Padding around the screenshots
 
@@ -67,7 +67,7 @@ const uint dxp_border_width = 0; ///< dxp window border
 ///
 /// NOTE: Setting timeout to values below 5 ms may severely increase CPU load.
 ///
-const auto dxp_screenshot_period = std::chrono::seconds (10);
+const auto dxp_screenshot_period = std::chrono::seconds (2);
 
 ///
 /// Desktop viewport:
@@ -80,7 +80,7 @@ const auto dxp_screenshot_period = std::chrono::seconds (10);
 ///
 /// Otherwise leave empty.
 ///
-const std::vector<uint32_t> dxp_viewport = {};
+const std::vector<uint32_t> dxp_viewport = {0,0,0,0,0,0,0,0};
 
 ///
 /// Key bindings:
@@ -98,7 +98,7 @@ struct dxp_keys
   static constexpr keys next = { "Down", "Right", "l", "j" };
   static constexpr keys prev = { "Left", "Up", "h", "k" };
   static constexpr keys slct = { "Return" };
-  static constexpr keys exit = { "Escape" };
+  static constexpr keys exit = { "Escape", "Cyrillic_hardsign" };
 };
 
 #endif /* ifndef DXP_CONFIG_HPP */

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -61,13 +61,16 @@ const bool dxp_center_y = false; ///< Center dxp on the monitor vertically
 
 const uint16_t dxp_padding = 3; ///< Padding around the screenshots
 
-color dxp_background = 0x444444;    ///< Window background
-color dxp_border_pres = 0xFFFFFF;   ///< Desktop preselection
-color dxp_border_nopres = 0x808080; ///< Desktop without preselection
+color dxp_background = 0x444444;               ///< Window background
+color dxp_border_pres = 0xFFFFFF;              ///< Desktop preselection
+color dxp_border_nopres = 0x808080;            ///< Desktop without preselection
+color dxp_layout_background = 0x000214;        ///< TODO(mmskv): Document
+color dxp_layout_window_border = 0x2c0069;     ///< TODO(mmskv): Document
+color dxp_layout_window_background = 0x04001a; ///< TODO(mmskv): Document
 
+const uint dxp_border_width = 0;          ///< dxp window border
 const uint16_t dxp_border_pres_width = 2; ///< Width of the preselection
-
-const uint dxp_border_width = 0; ///< dxp window border
+const uint dxp_desktop_layout_window_border_size = 2; ///< TODO(mmskv): Document
 
 ///
 /// How often to take screenshots.

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -12,6 +12,15 @@ using color = const uint32_t;
 using keys = std::array<std::string_view, keys_size>;
 
 ///
+/// Whether to show desktop screenshots.
+///
+/// True: Display desktop screenshots.
+///       Display desktop layouts if no screenshots are available.
+/// False: Always display desktop layouts.
+///
+const bool dxp_do_screenshots = true;
+
+///
 /// Dimensions of the screenshots that will be displayed.
 ///
 /// Specifying width will stack desktops vertically.
@@ -22,7 +31,7 @@ using keys = std::array<std::string_view, keys_size>;
 /// Actual window width will be equal to dxp_width + (dxp_padding * 2)
 ///
 const uint dxp_width = 0;
-const uint dxp_height = 175;
+const uint dxp_height = 150;
 
 ///
 /// Name of the monitor to put window on. Will use primary if unset.
@@ -48,7 +57,7 @@ const float dxp_y = 0; ///< Y coordinate of window's corner
 /// If centering is enabled, corresponding coordinate will be ignored
 ///
 const bool dxp_center_x = true;  ///< Center dxp on the monitor horizontally
-const bool dxp_center_y = true; ///< Center dxp on the monitor vertically
+const bool dxp_center_y = false; ///< Center dxp on the monitor vertically
 
 const uint16_t dxp_padding = 3; ///< Padding around the screenshots
 
@@ -67,7 +76,7 @@ const uint dxp_border_width = 0; ///< dxp window border
 ///
 /// NOTE: Setting timeout to values below 5 ms may severely increase CPU load.
 ///
-const auto dxp_screenshot_period = std::chrono::seconds (2);
+const auto dxp_screenshot_period = std::chrono::seconds (10);
 
 ///
 /// Desktop viewport:
@@ -80,7 +89,7 @@ const auto dxp_screenshot_period = std::chrono::seconds (2);
 ///
 /// Otherwise leave empty.
 ///
-const std::vector<uint32_t> dxp_viewport = {0,0,0,0,0,0,0,0};
+const std::vector<uint32_t> dxp_viewport = {};
 
 ///
 /// Key bindings:
@@ -98,7 +107,7 @@ struct dxp_keys
   static constexpr keys next = { "Down", "Right", "l", "j" };
   static constexpr keys prev = { "Left", "Up", "h", "k" };
   static constexpr keys slct = { "Return" };
-  static constexpr keys exit = { "Escape", "Cyrillic_hardsign" };
+  static constexpr keys exit = { "Escape" };
 };
 
 #endif /* ifndef DXP_CONFIG_HPP */

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -35,9 +35,12 @@ dxp_daemon::dxp_daemon ()
       dxp_socket_desktop p;
 
       p.id = i;
+      p.active = false;
+      p.width = desktops[i].width;
+      p.height = desktops[i].height;
       p.pixmap_len = desktops[i].pixmap_width * desktops[i].pixmap_height * 4U;
-      p.width = desktops[i].pixmap_width;
-      p.height = desktops[i].pixmap_height;
+      p.pixmap_width = desktops[i].pixmap_width;
+      p.pixmap_height = desktops[i].pixmap_height;
 
       // Copying pixmap from desktops into socket pixmaps
       p.pixmap = desktops[i].pixmap; // Should be as fast as memcpy
@@ -61,7 +64,7 @@ dxp_daemon::run ()
         {
           throw std::runtime_error (
               "The amount of virtual desktops specified in the config does not "
-              "match the amount of your virtual deskops in your system.");
+              "match the amount of virtual deskops in your system.");
         }
 
       this->socket_desktops_lock.lock ();
@@ -69,6 +72,7 @@ dxp_daemon::run ()
 
       // Copying pixmap from desktops into socket pixmaps
       this->socket_desktops[current].pixmap = this->desktops[current].pixmap;
+      this->socket_desktops[current].active = true;
 
       this->socket_desktops_lock.unlock ();
 

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -36,6 +36,8 @@ dxp_daemon::dxp_daemon ()
 
       p.id = i;
       p.active = false;
+      p.x = desktops[i].x;
+      p.y = desktops[i].y;
       p.width = desktops[i].width;
       p.height = desktops[i].height;
       p.pixmap_len = desktops[i].pixmap_width * desktops[i].pixmap_height * 4U;

--- a/src/desktop.hpp
+++ b/src/desktop.hpp
@@ -67,35 +67,23 @@ public:
   void save_screen ();
 
   /**
+   * Apply a horizontal box filter (low pass) to the image.
+   */
+  void box_blur_horizontal (uint radius);
+  /**
+   * Apply a vertical box filter (low pass) to the image.
+   */
+  void box_blur_vertical (uint radius);
+
+  /**
    * Resize image to specified dimensions with nearest neighbour algorithm
    */
-  static void
-  nn_resize (const uint8_t *input, ///< Input RGBA 1D array pointer
-             uint8_t *output,      ///< Output RGBA 1D array pointers
-             int source_width,     /* Dimensions of unresized screenshot */
-             int source_height,
-             int target_width, /* Dimensions of screenshot after resize */
-             int target_height);
+  void nn_resize ();
 
   /**
    * Resize image to specified dimensions with bilinear interpolation algorithm
    */
-  static void
-  bilinear_resize (const uint8_t *input, ///< Input RGBA 1D array pointer
-                   uint8_t *output,      ///< Output RGBA 1D array pointers
-                   int source_width, /* Dimensions of unresized screenshot */
-                   int source_height,
-                   int target_width, /* Dimensions of screenshot after resize */
-                   int target_height);
+  void bilinear_resize ();
 };
-
-/**
- * Apply a horizontal box filter (low pass) to the image.
- */
-void box_blur_horizontal (uint8_t *image, int width, int height, uint radius);
-/**
- * Apply a vertical box filter (low pass) to the image.
- */
-void box_blur_vertical (uint8_t *image, int width, int height, uint radius);
 
 #endif /* ifndef DESKTOP_PIXMAP_HPP */

--- a/src/dxp.cpp
+++ b/src/dxp.cpp
@@ -19,18 +19,14 @@ main ()
   try
     {
       // Get screenshots from socket or create them manually
-      // if (dxp_do_screenshots)
-      //   {
-      dxp_socket client;
-      auto v = client.get_desktops ();
-      //   }
-      // else
-      //   {
-      //     auto v = get_desktops ();
-      //  }
+      std::vector<dxp_socket_desktop> v{};
+      if (dxp_do_screenshots)
+        {
+          dxp_socket client;
+          v = client.get_desktops ();
+        }
 
       window w (v);
-      auto windows = get_windows (window::c, window::root);
 
       // Handling incoming events
       // Freeing it with free() is not specified in the docs, but it works

--- a/src/dxp.cpp
+++ b/src/dxp.cpp
@@ -18,11 +18,19 @@ main ()
 {
   try
     {
-      // Get screenshots from socket
+      // Get screenshots from socket or create them manually
+      // if (dxp_do_screenshots)
+      //   {
       dxp_socket client;
       auto v = client.get_desktops ();
+      //   }
+      // else
+      //   {
+      //     auto v = get_desktops ();
+      //  }
 
       window w (v);
+      auto windows = get_windows (window::c, window::root);
 
       // Handling incoming events
       // Freeing it with free() is not specified in the docs, but it works

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -198,14 +198,14 @@ dxp_socket::send_desktops_on_event (
                       "Failed to send number of desktops to dxp");
 
           // Writes from second to `num+1` * 2 -- sending desktops
-          for (const auto &p : desktops)
+          for (const auto &d : desktops)
             {
               // Sending everything except raw pixmap
-              write_unix (data_fd, &p, offsetof (dxp_socket_desktop, pixmap),
+              write_unix (data_fd, &d, offsetof (dxp_socket_desktop, pixmap),
                           "Failed to send desktop data to dxp");
 
               // Sending pixmap
-              write_unix (data_fd, p.pixmap.data (), p.pixmap_len,
+              write_unix (data_fd, d.pixmap.data (), d.pixmap_len,
                           "Failed to send raw desktop pixmap to dxp");
             }
         }

--- a/src/socket.hpp
+++ b/src/socket.hpp
@@ -17,9 +17,12 @@ constexpr const char *k_socket_path = "/tmp/dxp.socket";
  */
 struct dxp_socket_desktop
 {
-  uint id; // _NET_CURRENT_DESKTOP
+  uint id;     // _NET_CURRENT_DESKTOP
+  bool active; ///< Whether this desktop contains a screenshot in the pixmap
   uint16_t width;
   uint16_t height;
+  uint16_t pixmap_width;
+  uint16_t pixmap_height;
   uint32_t pixmap_len;
   std::vector<uint8_t> pixmap; ///< Pixmap in RBGA format
 };

--- a/src/socket.hpp
+++ b/src/socket.hpp
@@ -1,39 +1,16 @@
 #ifndef DEXPO_SOCKET_HPP
 #define DEXPO_SOCKET_HPP
 
-#include <atomic>      // for atomic
-#include <cstdint>     // for uint8_t, uint16_t, uint32_t
-#include <mutex>       // for mutex
-#include <stdexcept>   // for runtime_error
-#include <string>      // for string
-#include <sys/types.h> // for uint
-#include <vector>      // for vector
+#include "xcb_util.hpp" // for dxp_socket_desktop, dxp_event
+#include <atomic>       // for atomic
+#include <cstdint>      // for uint8_t, uint16_t, uint32_t
+#include <mutex>        // for mutex
+#include <stdexcept>    // for runtime_error
+#include <string>       // for string
+#include <sys/types.h>  // for uint
+#include <vector>       // for vector
 
 constexpr const char *k_socket_path = "/tmp/dxp.socket";
-
-/**
- * Dekstop struct that will be transferred over socket
- * Contains only necessary data
- */
-struct dxp_socket_desktop
-{
-  uint id;     // _NET_CURRENT_DESKTOP
-  bool active; ///< Whether this desktop contains a screenshot in the pixmap
-  uint16_t width;
-  uint16_t height;
-  uint16_t pixmap_width;
-  uint16_t pixmap_height;
-  uint32_t pixmap_len;
-  std::vector<uint8_t> pixmap; ///< Pixmap in RBGA format
-};
-
-/**
- * All commands that can be sent by client to daemon
- */
-enum dxp_event
-{
-  RequestDesktops = 1 // Request all pixmaps
-};
 
 class dxp_socket
 {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -60,7 +60,7 @@ window::set_window_dimensions ()
 
   for (const auto &d : this->desktops)
     {
-      dynamic += dxp_horizontal_stacking ? d.width : d.height;
+      dynamic += dxp_horizontal_stacking ? d.pixmap_width : d.pixmap_height;
       dynamic += dxp_padding + 2 * dxp_border_pres_width;
     }
 
@@ -179,9 +179,9 @@ window::draw_desktops ()
   for (const auto &desktop : this->desktops)
     {
       xcb_put_image (window::c, XCB_IMAGE_FORMAT_Z_PIXMAP,
-                     this->xcb_id,                  /* Pixmap to put image on */
-                     window::gc,                    /* Graphic context */
-                     desktop.width, desktop.height, /* Dimensions */
+                     this->xcb_id, /* Pixmap to put image on */
+                     window::gc,   /* Graphic context */
+                     desktop.pixmap_width, desktop.pixmap_height,
                      x, /* Destination X coordinate */
                      y, /* Destination Y coordinate */
                      0, window::screen->root_depth,
@@ -189,12 +189,12 @@ window::draw_desktops ()
                      desktop.pixmap.data ());
       if (dxp_horizontal_stacking)
         {
-          x += desktop.width;
+          x += desktop.pixmap_width;
           x += dxp_padding + 2 * dxp_border_pres_width;
         }
       else if (dxp_vertical_stacking)
         {
-          y += desktop.height;
+          y += desktop.pixmap_height;
           y += dxp_padding + 2 * dxp_border_pres_width;
         };
     }
@@ -218,7 +218,8 @@ window::get_desktop_coord (uint desktop_id)
         }
 
       // Append width for horizontal stacking and height for vertical
-      pos += dxp_horizontal_stacking ? desktop.width : desktop.height;
+      pos += dxp_horizontal_stacking ? desktop.pixmap_width
+                                     : desktop.pixmap_height;
       pos += dxp_padding + 2 * dxp_border_pres_width;
     }
   return 0;
@@ -237,10 +238,10 @@ window::get_hover_desktop (int16_t x, int16_t y)
   if (dxp_vertical_stacking)
     {
       // Check if cursor is inside of the desktop
-      if (x >= dxp_padding &&           // Not to the left
-          x <= d.width + dxp_padding && // Not to the right
-          y >= d.y &&                   // Not above
-          y <= d.height + d.y)          // Not below
+      if (x >= dxp_padding &&                  // Not to the left
+          x <= d.pixmap_width + dxp_padding && // Not to the right
+          y >= d.y &&                          // Not above
+          y <= d.pixmap_height + d.y)          // Not below
         {
           return d.id;
         }
@@ -248,10 +249,10 @@ window::get_hover_desktop (int16_t x, int16_t y)
   else if (dxp_horizontal_stacking)
     {
       // Check if cursor is inside of the desktop
-      if (x >= d.x &&                  // To the right of left border
-          x <= d.width + d.x &&        // To the left of right border
-          y >= dxp_padding &&          // Not above
-          y <= d.height + dxp_padding) // Not below
+      if (x >= d.x &&                         // To the right of left border
+          x <= d.pixmap_width + d.x &&        // To the left of right border
+          y >= dxp_padding &&                 // Not above
+          y <= d.pixmap_height + dxp_padding) // Not below
         {
           return d.id;
         }
@@ -269,10 +270,10 @@ window::get_hover_desktop (int16_t x, int16_t y)
         {
           auto desktop_y = get_desktop_coord (d.id);
           // Check if cursor is inside of the desktop
-          if (x >= dxp_padding &&           // Not to the left
-              x <= d.width + dxp_padding && // Not to the right
-              y >= desktop_y &&             // Not above
-              y <= d.height + desktop_y)    // Not below
+          if (x >= dxp_padding &&                  // Not to the left
+              x <= d.pixmap_width + dxp_padding && // Not to the right
+              y >= desktop_y &&                    // Not above
+              y <= d.pixmap_height + desktop_y)    // Not below
             {
               // Cache new desktop
               recent_hover_desktop = { { d }, 0, desktop_y };
@@ -283,10 +284,10 @@ window::get_hover_desktop (int16_t x, int16_t y)
         {
           auto desktop_x = get_desktop_coord (d.id);
           // Check if cursor is inside of the desktop
-          if (x >= desktop_x &&            // To the right of left border
-              x <= d.width + desktop_x &&  // To the left of right border
-              y >= dxp_padding &&          // Not above
-              y <= d.height + dxp_padding) // Not below
+          if (x >= desktop_x &&                   // To the right of left border
+              x <= d.pixmap_width + desktop_x &&  // To the left of right border
+              y >= dxp_padding &&                 // Not above
+              y <= d.pixmap_height + dxp_padding) // Not below
             {
               // Cache new desktop
               recent_hover_desktop = { { d }, desktop_x, 0 };
@@ -308,8 +309,8 @@ window::draw_desktop_border (uint desktop_id, uint32_t color)
   int16_t x = 0;
   int16_t y = 0;
 
-  uint16_t width = this->desktops[desktop_id].width;
-  uint16_t height = this->desktops[desktop_id].height;
+  uint16_t width = this->desktops[desktop_id].pixmap_width;
+  uint16_t height = this->desktops[desktop_id].pixmap_height;
 
   if (dxp_vertical_stacking)
     {

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -3,6 +3,7 @@
 
 #include "drawable.hpp" // for drawable
 #include "socket.hpp"   // for dxp_socket_desktop
+#include "xcb_util.hpp" // for window_info
 #include <cstdint>      // for int16_t, uint32_t
 #include <sys/types.h>  // for uint
 #include <vector>       // for vector
@@ -30,7 +31,8 @@ public:
   uint32_t xcb_id;
   std::vector<dxp_socket_desktop> desktops; ///< Desktops received from daemon
   dxp_window_desktop recent_hover_desktop;  ///< Recently cached hover desktop
-  uint pres;                                ///< id of the preselected desktop
+  std::vector<window_info> windows; ///< List window_info for all windows
+  uint pres;                        ///< id of the preselected desktop
 
   explicit window (const std::vector<dxp_socket_desktop> &desktops);
   ~window ();
@@ -51,6 +53,22 @@ public:
    * Create an empty window to later place gui in it.
    */
   void create_window ();
+
+  /**
+   * Draw windows layout on the desktop
+   *
+   * Used to fill a desktop with windows layout when there are no screenshots
+   * of the desktop available
+   */
+  void draw_windows_layout ();
+
+  /**
+   * Draw border over window
+   *
+   * Used to highlight window when it is preselected
+   * Or to highlight all windows that are not preselected
+   */
+  void draw_window_border (window_info window, uint32_t color);
 
   /**
    * Draw desktops on the window

--- a/src/xcb_util.cpp
+++ b/src/xcb_util.cpp
@@ -18,7 +18,7 @@ check (xcb_generic_error_t *e, const std::string &msg)
 };
 
 /**
- * Get a vector with EWMH property values
+ * Get a vector with EWMH property values by name
  *
  * @note vector size is inconsistent so vector may contain other data
  */
@@ -208,7 +208,7 @@ get_desktops (xcb_connection_t *c, xcb_window_t root)
               "`dxp_viewport`.");
         }
 
-      info.push_back (desktop_info{ i, x, y, width, height });
+      info.emplace_back (/* i, */ x, y, width, height);
     }
 
   return info;
@@ -223,15 +223,14 @@ get_current_desktop (xcb_connection_t *c, xcb_window_t root)
   return get_property_value (c, root, "_NET_CURRENT_DESKTOP")[0];
 };
 
-constexpr uint8_t k_event_data32_length = 5;
+constexpr uint8_t ewmh_event_data32_number = 5; // From EWMH specs
 /**
  * Generating and sending client message to the x server
  */
 void
 send_xcb_message (xcb_connection_t *c, xcb_window_t root, const char *msg,
-                  const std::array<uint32_t, k_event_data32_length> &data)
+                  const std::array<uint32_t, ewmh_event_data32_number> &data)
 {
-  // Making a double pointer to error doesn't look right
   xcb_generic_error_t *e = nullptr;
 
   auto atom_cookie = xcb_intern_atom (c, 0, strlen (msg), msg);

--- a/src/xcb_util.cpp
+++ b/src/xcb_util.cpp
@@ -24,19 +24,18 @@ check (xcb_generic_error_t *e, const std::string &msg)
  */
 std::vector<uint32_t>
 get_property_value (xcb_connection_t *c, xcb_window_t root,
-                    const char *atom_name)
+                    const std::string &name)
 {
-  xcb_generic_error_t *e = nullptr; // TODO(mmskv): Check for memory leak
+  xcb_generic_error_t *e = nullptr;
 
-  auto atom_cookie = xcb_intern_atom (c, 0, strlen (atom_name), atom_name);
+  auto atom_cookie = xcb_intern_atom (c, 0, name.length (), name.c_str ());
   auto atom_reply = xcb_unique_ptr<xcb_intern_atom_reply_t> (
       xcb_intern_atom_reply (c, atom_cookie, &e));
   check (e, "XCB error while getting atom reply");
 
   auto atom = atom_reply
                   ? atom_reply->atom
-                  : throw std::runtime_error (
-                      std::string ("Could not get atom for ") + atom_name);
+                  : throw std::runtime_error ("Could not get atom for " + name);
 
   /* Getting property from atom */
 

--- a/src/xcb_util.cpp
+++ b/src/xcb_util.cpp
@@ -269,39 +269,34 @@ ewmh_change_desktop (xcb_connection_t *c, xcb_window_t root, uint destkop_id)
   send_xcb_message (c, root, "_NET_CURRENT_DESKTOP", { destkop_id });
 }
 
-std::vector<uint32_t>
-get_desktop_windows_ids (xcb_connection_t *c, xcb_window_t root,
-                         uint32_t desktop)
+std::vector<window_info>
+get_windows (xcb_connection_t *c, xcb_window_t root)
 {
-  std::vector<uint32_t> desktop_windows_ids;
-  auto list = get_property_value (c, root, "_NET_CLIENT_LIST");
-  for (uint32_t client : list)
-    {
-      bool is_on_desktop
-          = (desktop
-             == get_property_value (c, client, "_NET_WINDOW_DESKTOP")[0]);
-      if (is_on_desktop)
-        {
-          desktop_windows_ids.push_back (client);
-        }
-    }
-  return desktop_windows_ids;
-}
+  xcb_generic_error_t *e = nullptr;
+  std::vector<window_info> windows;
 
-std::vector<render_info>
-get_prerenders (xcb_connection_t *c, xcb_window_t root, uint desktop)
-{
-  std::vector<render_info> info;
-  std::vector<uint32_t> ids = get_desktop_windows_ids (c, root, desktop);
-  xcb_generic_error_t *e = nullptr; // TODO(mmskv): Check for memory leak
-  for (uint32_t id : ids)
+  std::vector<uint32_t> desktop_windows_ids;
+  auto ids = get_property_value (c, root, "_NET_CLIENT_LIST");
+
+  windows.reserve (ids.size ());
+  for (const auto id : ids)
     {
+      /* Get window dimensions */
+
       auto geometry_cookie = xcb_get_geometry (c, id);
-      auto geometry = xcb_unique_ptr<xcb_get_geometry_reply_t> (xcb_get_geometry_reply (c, geometry_cookie, &e));
+      auto geometry = xcb_unique_ptr<xcb_get_geometry_reply_t> (
+          xcb_get_geometry_reply (c, geometry_cookie, &e));
       check (e, "XCB error while getting geometry reply");
-      // auto icons = get_property_value(c, id, "_NET_WM_ICONS");
-      render_info id_info={geometry.get()->x, geometry.get()->y, geometry.get()->width, geometry.get()->height};
-      info.push_back(id_info);
+
+      /* Get window's desktop id */
+
+      auto desktop_id = get_property_value (c, id, "_NET_WM_DESKTOP");
+
+      // TODO(sthussky): Get suitable window icon
+
+      windows.emplace_back (desktop_id[0], uint (geometry->x),
+                            uint (geometry->y), geometry->width,
+                            geometry->height);
     }
-  return info;
+  return windows;
 }

--- a/src/xcb_util.cpp
+++ b/src/xcb_util.cpp
@@ -268,6 +268,10 @@ ewmh_change_desktop (xcb_connection_t *c, xcb_window_t root, uint destkop_id)
   send_xcb_message (c, root, "_NET_CURRENT_DESKTOP", { destkop_id });
 }
 
+/**
+ * Get information about all windows, including ids, related desktops,
+ * geometries and icons
+ */
 std::vector<window_info>
 get_windows (xcb_connection_t *c, xcb_window_t root)
 {
@@ -291,11 +295,10 @@ get_windows (xcb_connection_t *c, xcb_window_t root)
 
       auto desktop_id = get_property_value (c, id, "_NET_WM_DESKTOP");
 
-      // TODO(sthussky): Get suitable window icon
-
       windows.emplace_back (desktop_id[0], uint (geometry->x),
                             uint (geometry->y), geometry->width,
-                            geometry->height);
+                            geometry->height,
+                            get_property_value (c, id, "_NET_WM_ICON"));
     }
   return windows;
 }

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -20,6 +20,32 @@
 #include <xcb/xproto.h>      // for xcb_keycode_t, xcb_window_t, xcb_keysym_t
 
 /**
+ * Dekstop struct that will be transferred over socket
+ * Contains only necessary data
+ */
+struct dxp_socket_desktop
+{
+  uint id;     // _NET_CURRENT_DESKTOP
+  bool active; ///< Whether this desktop contains a screenshot in the pixmap
+  int16_t x;   ///< Relative to the root
+  int16_t y;   ///< Relative to the root
+  uint16_t width;
+  uint16_t height;
+  uint16_t pixmap_width;
+  uint16_t pixmap_height;
+  uint32_t pixmap_len;
+  std::vector<uint8_t> pixmap; ///< Pixmap in RBGA format
+};
+
+/**
+ * All commands that can be sent by client to daemon
+ */
+enum dxp_event
+{
+  RequestDesktops = 1 // Request all pixmaps
+};
+
+/**
  * Virtual desktop information
  */
 struct desktop_info

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -57,7 +57,7 @@ struct window_info
   uint y;
   uint width;
   uint height;
-  // xcb_pixmap_t *icon ; TODO(sthussky): implement this
+  std::vector<uint32_t> icons; ///< _NET_WM_ICON value
 };
 
 class xcb_error : public std::runtime_error

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -255,4 +255,16 @@ get_keycodes (xcb_connection_t *c)
   return keycodes;
 }
 
+struct render_info{
+  uint x;
+  uint y;
+  uint width;
+  uint height;
+  //xcb_pixmap_t *icon ; TODO(sthussky): implement this
+};
+
+std::vector <uint32_t> get_desktop_windows(xcb_connection_t *c, xcb_window_t root, uint32_t desktop);
+
+std::vector <render_info> get_prerenders(xcb_connection_t *c, xcb_window_t root, uint desktop);
+
 #endif /* ifndef DEXPO_XCB_HPP */

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -24,7 +24,7 @@
  */
 struct desktop_info
 {
-  uint id; // XXX Is it necessary?
+  // uint id;
   int x;
   int y;
   uint width;
@@ -52,7 +52,7 @@ struct monitor_info
  */
 struct window_info
 {
-  uint id; ///< Id of the desktop the window belongs to
+  uint desktop; ///< Id of the desktop the window belongs to
   uint x;
   uint y;
   uint width;

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -79,8 +79,8 @@ struct monitor_info
 struct window_info
 {
   uint desktop; ///< Id of the desktop the window belongs to
-  uint x;
-  uint y;
+  int x;
+  int y;
   uint width;
   uint height;
   std::vector<uint32_t> icons; ///< _NET_WM_ICON value
@@ -156,9 +156,14 @@ void ewmh_change_desktop (xcb_connection_t *c, xcb_window_t root,
                           uint destkop_id);
 
 /**
- * Returns an array of window informations
+ * Get information about all windows, including ids, related desktops,
+ * geometries and icons.
+ *
+ * Desktops are used to calculate real window coordinates
  */
-std::vector<window_info> get_windows (xcb_connection_t *c, xcb_window_t root);
+std::vector<window_info>
+get_windows (xcb_connection_t *c, xcb_window_t root,
+             std::vector<dxp_socket_desktop> &desktops);
 
 /*******************************************************************************
  * XKB Related code

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -45,6 +45,21 @@ struct monitor_info
   std::string name;
 };
 
+/**
+ * Information about window on a desktop.
+ *
+ * Used to draw desktop layouts in place of desktop screenshots
+ */
+struct window_info
+{
+  uint id; ///< Id of the desktop the window belongs to
+  uint x;
+  uint y;
+  uint width;
+  uint height;
+  // xcb_pixmap_t *icon ; TODO(sthussky): implement this
+};
+
 class xcb_error : public std::runtime_error
 {
 public:
@@ -113,6 +128,11 @@ uint get_current_desktop (xcb_connection_t *c, xcb_window_t root);
  */
 void ewmh_change_desktop (xcb_connection_t *c, xcb_window_t root,
                           uint destkop_id);
+
+/**
+ * Returns an array of window informations
+ */
+std::vector<window_info> get_windows (xcb_connection_t *c, xcb_window_t root);
 
 /*******************************************************************************
  * XKB Related code
@@ -253,17 +273,5 @@ get_keycodes (xcb_connection_t *c)
 
   return keycodes;
 }
-
-struct render_info{
-  uint x;
-  uint y;
-  uint width;
-  uint height;
-  //xcb_pixmap_t *icon ; TODO(sthussky): implement this
-};
-
-std::vector <uint32_t> get_desktop_windows(xcb_connection_t *c, xcb_window_t root, uint32_t desktop);
-
-std::vector <render_info> get_prerenders(xcb_connection_t *c, xcb_window_t root, uint desktop);
 
 #endif /* ifndef DEXPO_XCB_HPP */

--- a/src/xcb_util.hpp
+++ b/src/xcb_util.hpp
@@ -84,8 +84,7 @@ xcb_unique_ptr (T *ptr)
  * @note vector size is inconsistent so vector may contain other data
  */
 std::vector<uint32_t> get_property_value (xcb_connection_t *c,
-                                          xcb_window_t root,
-                                          const char *atom_name);
+                                          xcb_window_t root, std::string &name);
 
 /**
  * Get monitor_info for each connected monitor


### PR DESCRIPTION
Implement functionality similar to other pagers (xfce, gnome and [this](https://github.com/vl409/rieman))
![image](https://user-images.githubusercontent.com/47359245/120083683-20736d00-c0d3-11eb-9206-fcf9a237340f.png)

This will deprecate dxpd's functionality

Closes #38 